### PR TITLE
adapted the way \label and \ref work.

### DIFF
--- a/doc/requirements specification/parts/application.lyx
+++ b/doc/requirements specification/parts/application.lyx
@@ -204,16 +204,12 @@ reference "/A40/"
 
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
-
-\emph on
 \begin_inset CommandInset label
 LatexCommand label
 name "/G20/"
 
 \end_inset
 
-
-\emph default
  
 \begin_inset ERT
 status open

--- a/doc/requirements specification/parts/application.lyx
+++ b/doc/requirements specification/parts/application.lyx
@@ -104,7 +104,7 @@ name "/A10/"
 
 \end_inset
 
-/A10/ Reengineering of existing software.
+ Reengineering of existing software.
 \end_layout
 
 \begin_layout Labeling
@@ -115,7 +115,7 @@ name "/A20/"
 
 \end_inset
 
-/A20/ Prototyping
+ Prototyping
 \end_layout
 
 \begin_layout Labeling
@@ -126,7 +126,7 @@ name "/A30/"
 
 \end_inset
 
-/A30/ Software development.
+ Software development.
  Early implementations of components can be analysed with Beagle in order
  to predict its performance in interaction with the software system.
 \end_layout
@@ -139,7 +139,7 @@ name "/A40/"
 
 \end_inset
 
-/A40/ Verifying of design and implementation
+ Verifying of design and implementation
 \end_layout
 
 \begin_layout Section
@@ -172,7 +172,7 @@ name "/G10/"
 
 \end_inset
 
-/G10/ 
+ 
 \begin_inset ERT
 status open
 
@@ -214,7 +214,7 @@ name "/G20/"
 
 
 \emph default
-/G20/ 
+ 
 \begin_inset ERT
 status open
 
@@ -245,7 +245,7 @@ name "/G30/"
 
 \end_inset
 
-/G30/ 
+ 
 \begin_inset ERT
 status open
 
@@ -304,7 +304,7 @@ name "/A100/"
 
 \end_inset
 
-/A100/ Desktop System (with Eclipse) with JRE
+ Desktop System (with Eclipse) with JRE
 \end_layout
 
 \begin_layout Labeling
@@ -315,8 +315,7 @@ name "/A110/"
 
 \end_inset
 
-/A110/ Server (optional), add possibility to run on Server as additional
- function
+ Server (optional), add possibility to run on Server as additional function
 \end_layout
 
 \end_body

--- a/doc/requirements specification/parts/purpose.lyx
+++ b/doc/requirements specification/parts/purpose.lyx
@@ -164,8 +164,7 @@ name "/C10/"
 
 \end_inset
 
-/C10/ Beagle shall enable the user to analyze given source code for its
- 
+ Beagle shall enable the user to analyze given source code for its 
 \begin_inset ERT
 status open
 
@@ -202,7 +201,7 @@ name "/C20/"
 
 \end_inset
 
-/C20/ Beagle shall automatically annotate its 
+ Beagle shall automatically annotate its 
 \begin_inset ERT
 status open
 
@@ -270,7 +269,7 @@ name "/OC10/"
 
 \end_inset
 
-/OC10/ Beagle should determine the aproximate probability in 
+ Beagle should determine the aproximate probability in 
 \begin_inset ERT
 status open
 
@@ -309,8 +308,8 @@ name "/OC20/"
 
 \end_inset
 
-/OC20/ The branch prohabilitys as a function of the input parameters should
- be annotated in the 
+ The branch prohabilitys as a function of the input parameters should be
+ annotated in the 
 \begin_inset ERT
 status open
 
@@ -334,7 +333,7 @@ name "/OC30/"
 
 \end_inset
 
-/OC30/ Beagle should determine in 
+ Beagle should determine in 
 \begin_inset ERT
 status open
 
@@ -371,8 +370,8 @@ name "/OC40/"
 
 \end_inset
 
-/OC40/ The number of loop executions as a function of the input parameters
- should be annotated in the 
+ The number of loop executions as a function of the input parameters should
+ be annotated in the 
 \begin_inset ERT
 status open
 
@@ -425,7 +424,7 @@ name "/B10/"
 
 \end_inset
 
-/B10/ Beagle does not perform actual measurements on source code.
+ Beagle does not perform actual measurements on source code.
 \end_layout
 
 \begin_layout Labeling
@@ -436,7 +435,7 @@ name "/B20/"
 
 \end_inset
 
-/B20/ Beagle does not reconstruct a model of the software's architecture.
+ Beagle does not reconstruct a model of the software's architecture.
 \end_layout
 
 \end_body

--- a/doc/requirements specification/requirements specification.lyx
+++ b/doc/requirements specification/requirements specification.lyx
@@ -267,6 +267,66 @@ Reference notation
 \end_layout
 
 \begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+%Renew the label command to get labels as we want them
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+makeatletter
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+renewcommand{
+\backslash
+label}[1]{%
+\end_layout
+
+\begin_layout Plain Layout
+
+	
+\backslash
+protected@write 
+\backslash
+@auxout {}{
+\backslash
+string 
+\backslash
+newlabel {#1}{{#1}{
+\backslash
+thepage}{#1}{#1}{}} }%
+\end_layout
+
+\begin_layout Plain Layout
+
+	
+\backslash
+hypertarget{#1}{#1}
+\end_layout
+
+\begin_layout Plain Layout
+
+}
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+makeatother 
+\end_layout
+
+\end_inset
+
 This document uses a fixed notation for all of its contents, making them
  referenceable: 
 \end_layout
@@ -350,7 +410,7 @@ name "/F10/"
 
 \end_inset
 
-/F10/ Foobar
+ Foobar
 \end_layout
 
 \begin_layout Plain Layout


### PR DESCRIPTION
`\label` was rewritten to
   a) have its ID printed when referenced
   b) print the ID when defined

`\ref` will automatically print the label’s ID