### PR TITLE
Fix Hyperref

### DIFF
--- a/doc/Requirements Specification/Parts/Terms and Definitions.lyx
+++ b/doc/Requirements Specification/Parts/Terms and Definitions.lyx
@@ -365,14 +365,6 @@ glspl{component}.
 
 \begin_layout Plain Layout
 
-%
-\backslash
-todo{add def.
- component-based software architecture}
-\end_layout
-
-\begin_layout Plain Layout
-
 
 \backslash
 newglossaryentry{component-based software architecture}{
@@ -407,22 +399,6 @@ gls{software architecture} ...
 
 \begin_layout Plain Layout
 
-\end_layout
-
-\begin_layout Plain Layout
-
-\end_layout
-
-\begin_layout Plain Layout
-
-\end_layout
-
-\begin_layout Plain Layout
-
-%
-\backslash
-todo{add def.
- resource demand}
 \end_layout
 
 \begin_layout Plain Layout
@@ -1345,7 +1321,6 @@ newglossaryentry{system deployer}{
 
 \end_layout
 
-
 \begin_layout Plain Layout
 
 \end_layout
@@ -1355,13 +1330,6 @@ newglossaryentry{system deployer}{
 
 \backslash
 newglossaryentry{Kieker}{
-\end_layout
-
-\begin_layout Plain Layout
-
-%
-\backslash
-todo{add a short but precise definition of Kieker}
 \end_layout
 
 \begin_layout Plain Layout
@@ -1378,7 +1346,6 @@ todo{add a short but precise definition of Kieker}
 
 }
 \end_layout
-
 
 \end_inset
 

--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -17,8 +17,10 @@
 \usepackage{listings}
 % Include the terms and definitions file if presents (e.g. only when acutally building the glossary).
 \InputIfFileExists{\string"Parts/Terms and Definitions.tex\string"}
+
+\renewcommand\todo{\errmessage{TODO tags are not supported anymore. Please use GitHub issues!}}
 \end_preamble
-\options english,draft
+\options english,final
 \use_default_options true
 \begin_modules
 enumitem
@@ -225,24 +227,6 @@ ation
 
 \backslash
 hyphenation{me-ta-mo-del} 
-\end_layout
-
-\end_inset
-
-
-\begin_inset ERT
-status open
-
-\begin_layout Plain Layout
-
-%Liste der ToDos (wird niemals in der finalen Version angezeigt werden):
-\end_layout
-
-\begin_layout Plain Layout
-
-
-\backslash
-listoftodos
 \end_layout
 
 \end_inset


### PR DESCRIPTION
fixes #43 

This PR sets the document mode back to `final`, which re-enables `hyperref` and re-introduces a more sophisticated font rendering.

The document mode shall not be set back to `draft` any more. `final` rendering is not slower (not that I noticed) and `hyperref` support is convenient during development.

Todo notes are not shown in `final`mode. I disabled `\todo`, such that the build fails with a warning message telling to use GitHub issues, when trying to use `\todo`