### PR TITLE
Inserted Paragraphs to Separate Mandatory and Optional Points

### DIFF
--- a/doc/Requirements Specification/Parts/Application.lyx
+++ b/doc/Requirements Specification/Parts/Application.lyx
@@ -286,7 +286,6 @@ name "/A30/"
 
  Beagle may be used for prototyping.
  Different implementations of a 
-
 \begin_inset ERT
 status open
 
@@ -299,8 +298,6 @@ gls{component}
 
 \end_inset
 
-
-\lang british
  modelled in the 
 \begin_inset ERT
 status open

--- a/doc/Requirements Specification/Parts/Data.lyx
+++ b/doc/Requirements Specification/Parts/Data.lyx
@@ -191,6 +191,10 @@ name "result PCM"
 Input
 \end_layout
 
+\begin_layout Paragraph
+Mandatory
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 \begin_inset CommandInset label
@@ -351,12 +355,8 @@ glspl{component}
  to the parts in the source code implementing them.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
-\begin_inset VSpace defskip
-\end_inset
-
-
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling
@@ -384,6 +384,10 @@ name "/OD20/"
 
 \begin_layout Section
 Output
+\end_layout
+
+\begin_layout Paragraph
+Mandatory
 \end_layout
 
 \begin_layout Labeling
@@ -423,12 +427,8 @@ glsuserii{internal action}
  execution time.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
-\begin_inset VSpace defskip
-\end_inset
-
-
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling

--- a/doc/Requirements Specification/Parts/Functional Requirements.lyx
+++ b/doc/Requirements Specification/Parts/Functional Requirements.lyx
@@ -135,6 +135,10 @@ reference "input artefacts"
 Measurement
 \end_layout
 
+\begin_layout Paragraph
+Mandatory
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 \begin_inset CommandInset label
@@ -331,12 +335,8 @@ reference "/F60/"
  and replace it with a set timeout or disable the timeout entirely.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
-\begin_inset VSpace defskip
-\end_inset
-
-
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling
@@ -491,6 +491,10 @@ glsuseri{component}
 Control
 \end_layout
 
+\begin_layout Paragraph
+Optional
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 \begin_inset CommandInset label
@@ -641,6 +645,10 @@ name "/OF180/"
 
 \begin_layout Section
 Result Annotation
+\end_layout
+
+\begin_layout Paragraph
+Mandatory
 \end_layout
 
 \begin_layout Labeling
@@ -848,15 +856,11 @@ name "/F250/"
 
 \end_inset
 
- Measurement results are saved onto a persistent medium to avoid data loss.
+ Measurement results are saved onto a persistent medium to avoid data loss
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
-\begin_inset VSpace defskip
-\end_inset
-
-
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling

--- a/doc/Requirements Specification/Parts/Non-Functional Requirements.lyx
+++ b/doc/Requirements Specification/Parts/Non-Functional Requirements.lyx
@@ -115,6 +115,10 @@ Reference notation for nice to have requirements is /OQ#/
 Dependencies
 \end_layout
 
+\begin_layout Paragraph
+Mandatory
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 \begin_inset CommandInset label
@@ -189,12 +193,8 @@ name "/Q30/"
  software.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
-\begin_inset VSpace defskip
-\end_inset
-
-
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling
@@ -274,6 +274,10 @@ name "/OQ40/"
 User Interface and Experience
 \end_layout
 
+\begin_layout Paragraph
+Mandatory
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 \begin_inset CommandInset label
@@ -322,12 +326,8 @@ More precise?!
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
-\begin_inset VSpace defskip
-\end_inset
-
-
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling

--- a/doc/Requirements Specification/Parts/Purpose.lyx
+++ b/doc/Requirements Specification/Parts/Purpose.lyx
@@ -551,6 +551,10 @@ Reference notation is /C#/
 
 \end_layout
 
+\begin_layout Paragraph
+Mandatory
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 \begin_inset CommandInset label
@@ -626,16 +630,10 @@ gls{Palladio}
  for analysis.
 \end_layout
 
-\begin_layout Standard
-\begin_inset VSpace defskip
-\end_inset
-
-
-\end_layout
-
-\begin_layout Standard
+\begin_layout Labeling
+\labelwidthstring 00.00.0000
 \begin_inset Note Note
-status open
+status collapsed
 
 \begin_layout Plain Layout
 Complements the above part.
@@ -658,6 +656,10 @@ Reference notation is /OC#/
 \end_inset
 
 
+\end_layout
+
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling

--- a/doc/Requirements Specification/Parts/Test Cases.lyx
+++ b/doc/Requirements Specification/Parts/Test Cases.lyx
@@ -119,6 +119,10 @@ Reference notation is /T#/.
 
 \end_layout
 
+\begin_layout Paragraph
+Mandatory
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 \begin_inset CommandInset label
@@ -387,12 +391,8 @@ reference "/F240/"
 .
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
-\begin_inset VSpace defskip
-\end_inset
-
-
+\begin_layout Paragraph
+Optional
 \end_layout
 
 \begin_layout Labeling


### PR DESCRIPTION
Alternative to #175, using paragraphs as discussed in yesterday’s meeting. I made another PR so we can compare.

I further removed the vspaces, as the paragraphs lead to enough separation from my point of view.