### PR TITLE
Fixed the /X#/ links.

### DIFF
--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -300,6 +300,17 @@ status open
 
 
 \backslash
+let
+\backslash
+labelorig
+\backslash
+label
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
 makeatletter
 \end_layout
 
@@ -309,29 +320,30 @@ makeatletter
 \backslash
 renewcommand{
 \backslash
-label}[1]{%
+label}[1]{
+\end_layout
+
+\begin_layout Plain Layout
+
+   
+\backslash
+edef
+\backslash
+@currentlabel{#1}% Set target label
+\end_layout
+
+\begin_layout Plain Layout
+
+	#1
 \end_layout
 
 \begin_layout Plain Layout
 
 	
 \backslash
-protected@write 
+phantomsection
 \backslash
-@auxout {}{
-\backslash
-string
-\backslash
-newlabel{#1}{{#1}{
-\backslash
-thepage}{#1}{#1}{}}}%
-\end_layout
-
-\begin_layout Plain Layout
-
-	
-\backslash
-hypertarget{#1}{#1}
+labelorig{#1}
 \end_layout
 
 \begin_layout Plain Layout


### PR DESCRIPTION
Fixes the links to the /X#/ lables ( #65 )

Finally!

[PDF](http://romanlangrehr.github.io/Beagle/branches/Fix-label/Requirements%20Specification.pdf)

Please try it wtih your favorite PDF viewer!
Note: Crome only jumps to the correct page, not the exact position. But that's probably a problem in chrome.

Tested with
 * FoxitReader
 * SumatraPDF
 * Chrome (only jumps to correct page...)