### PR TITLE
Fix TOC links

### DIFF
--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -607,6 +607,34 @@ status open
 
 
 \backslash
+newpage
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+quad %phantom item
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+newpage
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+phantomsection
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
 addcontentsline{toc}{chapter}{
 \backslash
 listfigurename}
@@ -619,6 +647,43 @@ listfigurename}
 
 \begin_layout Standard
 \begin_inset FloatList figure
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+
+\backslash
+newpage
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+quad %phantom item
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+newpage
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+phantomsection
+\end_layout
 
 \end_inset
 


### PR DESCRIPTION
The TOC links for List of figures and the Bibliography work now!
Fixes #65 

[PDF](http://romanlangrehr.github.io/Beagle/branches/fix-toc/Requirements%20Specification.pdf)

To be honestly: This is a pretty dirty fix for the TOC links and maybe has to be adapted a little bit, when our Glossary needs one more page (because then the empy page just before the list of figures disappers), but I think it's much better than the wrong links.

Thanks to `\phantomsection`!