### PR TITLE
Fix a bunch of SRS warnings, minor improvements along the way

### DIFF
--- a/doc/Requirements Specification/Parts/Application.lyx
+++ b/doc/Requirements Specification/Parts/Application.lyx
@@ -164,7 +164,6 @@ gls{Palladio}
 
 
 \begin_inset Float figure
-placement h
 wide false
 sideways false
 status open
@@ -274,7 +273,6 @@ gls{PCM}
 
 ), which can hence be fixed in time.
 \begin_inset Float figure
-placement h
 wide false
 sideways false
 status open
@@ -397,7 +395,6 @@ Gls{Palladio}
  As performance is multi-dimensional, this can lead to more precise information
  about the different implementation's effects on the system's runtime.
 \begin_inset Float figure
-placement h
 wide false
 sideways false
 status open
@@ -505,7 +502,6 @@ gls{PCM}
  With this approach, differences and problems in the implementation can
  be detected and resolved easier.
 \begin_inset Float figure
-placement h
 wide false
 sideways false
 status open

--- a/doc/Requirements Specification/Parts/Non-Functional Requirements.lyx
+++ b/doc/Requirements Specification/Parts/Non-Functional Requirements.lyx
@@ -324,6 +324,30 @@ name "/Q110/"
 
 \end_inset
 
+ Beagle uses native Eclipse features for its 
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+
+\backslash
+gls{GUI}
+\end_layout
+
+\end_inset
+
+.
+\end_layout
+
+\begin_layout Labeling
+\labelwidthstring 00.00.0000
+\begin_inset CommandInset label
+LatexCommand label
+name "/Q120/"
+
+\end_inset
+
  Beagle can be controlled by context sensitive menus in Eclipse.
  
 \begin_inset Note Note
@@ -463,7 +487,7 @@ status open
 
 
 \backslash
-gls{GUI}
+glsentryshort{GUI}
 \end_layout
 
 \end_inset

--- a/doc/Requirements Specification/Parts/Test Cases.lyx
+++ b/doc/Requirements Specification/Parts/Test Cases.lyx
@@ -363,14 +363,14 @@ name "/T70/"
  Tests 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "/F60/"
+reference "/F50/"
 
 \end_inset
 
  and 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "/F70/"
+reference "/F60/"
 
 \end_inset
 
@@ -825,7 +825,7 @@ name "/OT100/"
  Tests 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "/OF180/"
+reference "/OF170/"
 
 \end_inset
 

--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -60,6 +60,16 @@
 % Adding package bookmark improves bookmarks handling.
 % More features and faster updated bookmarks.
 \usepackage{bookmark}
+
+% Set the PDF metadata
+\hypersetup{
+    pdftitle={Beagle --- Software Requirements Specification},
+    pdfsubject={Beagle is a tool for automatic dynamic source code analysis in order to find resource demands of component based software’s components’ internal actions.},
+    pdfauthor={Annika Berger, Joshua Gleitze, Roman Langrehr, Christoph Michelbach, Ansgar Spiegler, Michael Vogt},
+    pdfkeywords={component based software, dynamic analysis, reverse engeneering, resource demands, SoMoX, Beagle, Palladio, Eclipse, Common Trace API},
+    pdfcreator={LyX, pdflatex},
+    pdfproducer={LaTeX}
+}
 \end_preamble
 \options english,final
 \use_default_options true
@@ -212,22 +222,6 @@ gls{naiive}
 \begin_layout Standard
 \begin_inset ERT
 status open
-
-\begin_layout Plain Layout
-
-% Set the PDF metadata
-\end_layout
-
-\begin_layout Plain Layout
-
-
-\backslash
-setpdf
-\end_layout
-
-\begin_layout Plain Layout
-
-\end_layout
 
 \begin_layout Plain Layout
 

--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -51,6 +51,10 @@
 
 % Make floats work batter with Koma book
 \usepackage{scrhack}
+
+% No page anchors and no page numbers for the title pages
+\hypersetup{pageanchor=false}
+\pagenumbering{gobble}
 \end_preamble
 \options english,final
 \use_default_options true
@@ -214,6 +218,22 @@ status open
 
 \backslash
 setpdf
+\end_layout
+
+\begin_layout Plain Layout
+
+\end_layout
+
+\begin_layout Plain Layout
+
+% Enable hyperref page anchors again
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+hypersetup{pageanchor=true}
 \end_layout
 
 \begin_layout Plain Layout

--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -734,7 +734,7 @@ status open
 
 
 \backslash
-glossarystyle{altlist}
+setglossarystyle{altlist}
 \end_layout
 
 \begin_layout Plain Layout

--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -68,7 +68,9 @@
     pdfauthor={Annika Berger, Joshua Gleitze, Roman Langrehr, Christoph Michelbach, Ansgar Spiegler, Michael Vogt},
     pdfkeywords={component based software, dynamic analysis, reverse engeneering, resource demands, SoMoX, Beagle, Palladio, Eclipse, Common Trace API},
     pdfcreator={LyX, pdflatex},
-    pdfproducer={LaTeX}
+    pdfproducer={LaTeX},
+    hidelinks,
+    breaklinks
 }
 \end_preamble
 \options english,final
@@ -78,7 +80,7 @@ enumitem
 \end_modules
 \maintain_unincluded_children false
 \language british
-\language_package babel
+\language_package auto
 \inputencoding utf8
 \fontencoding global
 \font_roman default

--- a/doc/Requirements Specification/Requirements Specification.lyx
+++ b/doc/Requirements Specification/Requirements Specification.lyx
@@ -77,6 +77,7 @@ enumitem
 \output_sync 0
 \bibtex_command default
 \index_command default
+\float_placement tph
 \paperfontsize default
 \spacing single
 \use_hyperref false


### PR DESCRIPTION
This PR reduces the warnings during rendering to a minimum. The warnings left are:

 * “Overfull \hbox” (it’s LaTeX, what did you expect? ;) )
 * “PDF inclusion: multiple pdfs with page group included in a single page” (not our fault)
 * “The package option \`english' should not be used with a more specific one (like \`british')” (thrown by babel, I’m not sure if we can fix that and still make sure we get British hyphenation)
 * Bibtex warnings, see #107 

The PR also introduces some changes:

 * The PDF metadata is set
 * A new non-functional requirement “/Q110/ Beagle uses native Eclipse features for its GUI.” was created
