### PR TITLE
Revised Environment

### DIFF
--- a/doc/Requirements Specification/Parts/Environment.lyx
+++ b/doc/Requirements Specification/Parts/Environment.lyx
@@ -288,7 +288,7 @@ gls{Beagle}
 \end_inset
 
  is running as this disturbs the measurement.
- To receive optimal measurements 
+ To receive optimal measurements,  
 \begin_inset ERT
 status open
 

--- a/doc/Requirements Specification/Parts/Environment.lyx
+++ b/doc/Requirements Specification/Parts/Environment.lyx
@@ -213,7 +213,7 @@ gls{code decorator}
 
 \end_inset
 
-
+.
 \end_layout
 
 \begin_layout Labeling


### PR DESCRIPTION
Enivironment should be fine, except that we have to think about /E10/ again:

> /E10/ Beagle should run on a Java 8 runtime environment (or higher) and Eclipse
distribution that is up to date with Eclipse Mars (4.5).

This implicates we are going to make sure Beagle will work with Java 9 or 10 or whatever.
Do we want to promise that?

fixes #196 