### PR TITLE
Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,9 @@ dist: trusty
 
 install:
   - sudo add-apt-repository -y ppa:cwchien/gradle && sudo apt-get update && sudo apt-get install -qq gradle-2.9
-
-before_script:
-  - cd doc/Requirements\ Specification/
-  - ./Install.sh
-  - cd $OLDPWD
   
 script:
-  - cd doc/Requirements\ Specification/
-  - ./Render.sh
-  - cd $OLDPWD
-  - gradle test
+  - gradle test srsinstall srs
   
 after_success:
   - ./deploy/Deploy\ Publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo add-apt-repository -y ppa:cwchien/gradle && sudo apt-get update && sudo apt-get install -qq gradle-2.9
   
 script:
-  - gradle test srsinstall srs
+  - gradle srsinstall build
   
 after_success:
   - ./deploy/Deploy\ Publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo add-apt-repository -y ppa:cwchien/gradle && sudo apt-get update && sudo apt-get install -qq gradle-2.9
   
 script:
-  - gradle srsinstall build
+  - gradle srsinstall build || gradle build --info
   
 after_success:
   - ./deploy/Deploy\ Publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: java
 sudo: required
 dist: trusty
 
+install:
+  - sudo add-apt-repository -y ppa:cwchien/gradle && sudo apt-get update && sudo apt-get install -qq gradle-2.9
+
 before_script:
   - cd doc/Requirements\ Specification/
   - ./Install.sh
@@ -12,6 +15,7 @@ script:
   - cd doc/Requirements\ Specification/
   - ./Render.sh
   - cd $OLDPWD
+  - gradle test
   
 after_success:
   - ./deploy/Deploy\ Publish.sh

--- a/build.gradle
+++ b/build.gradle
@@ -18,3 +18,48 @@ repositories {
 dependencies {
 	testCompile group: 'junit', name: 'junit', version: '4.+'
 }
+
+task srs(type: Exec) {
+	description 'Renders the Requirements Specification.'
+	
+	inputs.dir "$projectDir/doc/Requirements Specification"
+	outputs.file "$buildDir/doc/Requirements Specification.pdf"
+	
+	def dest = file("$buildDir/doc/")
+	def logdest = file("$buildDir/reports/Requirements Specification Render.log")
+	
+	workingDir "$projectDir/doc/Requirements Specification/"
+	args dest, logdest, 'srs-only'
+		
+	switch (System.getProperty('os.name').toLowerCase().split()[0]) {
+		case 'windows':
+			executable 'Render.bat '
+    	break
+		case 'linux':
+    		executable './Render.sh'
+    		break
+		default:
+    		throw new Exception('Sorry, we don’t support your operating system for building the SRS!')
+	}
+	
+	// only print the output for log level info or higher
+	logging.captureStandardOutput LogLevel.INFO
+}
+
+task srsinstall(type: Exec) {
+	description 'Sets up the environment for rendering the srs, but only if the srs is out of date.'	
+	
+	inputs.dir "$projectDir/doc/Requirements Specification"
+	outputs.file "$buildDir/doc/Requirements Specification.pdf"
+	
+	if (!System.getProperty('os.name').toLowerCase().contains('linux')) {
+		throw new Exception('Sorry, we only support linux for automatic setup of the srs render environment. Please refer to doc/Development Setup.md')
+	}
+	
+	workingDir "$projectDir/doc/Requirements Specification/"
+	executable './Install.sh'
+	
+	// only print the output for log level info or higher
+	logging.captureStandardOutput LogLevel.INFO
+	logging.captureStandardError LogLevel.INFO
+}

--- a/build.gradle
+++ b/build.gradle
@@ -69,3 +69,5 @@ task srsinstall(type: Exec) {
 	logging.captureStandardOutput LogLevel.INFO
 	logging.captureStandardError LogLevel.INFO
 }
+
+build.dependsOn srs

--- a/build.gradle
+++ b/build.gradle
@@ -29,17 +29,21 @@ task srs(type: Exec) {
 	def logdest = file("$buildDir/reports/Requirements Specification Render.log")
 	
 	workingDir "$projectDir/doc/Requirements Specification/"
-	args dest, logdest, 'srs-only'
-		
+	
 	switch (System.getProperty('os.name').toLowerCase().split()[0]) {
 		case 'windows':
-			executable 'Render.bat '
+			commandLine 'cmd', '/c', 'Render.bat', dest, logdest, 'srs-only'
     	break
 		case 'linux':
+			args dest, logdest, 'srs-only'
     		executable './Render.sh'
     		break
-		default:
+	}
+	
+	doFirst {
+		if (!System.getProperty('os.name').toLowerCase().contains('linux') && !System.getProperty('os.name').toLowerCase().contains('windows')) {
     		throw new Exception('Sorry, we don’t support your operating system for building the SRS!')
+		}
 	}
 	
 	// only print the output for log level info or higher
@@ -52,8 +56,10 @@ task srsinstall(type: Exec) {
 	inputs.dir "$projectDir/doc/Requirements Specification"
 	outputs.file "$buildDir/doc/Requirements Specification.pdf"
 	
-	if (!System.getProperty('os.name').toLowerCase().contains('linux')) {
-		throw new Exception('Sorry, we only support linux for automatic setup of the srs render environment. Please refer to doc/Development Setup.md')
+	doFirst {
+		if (!System.getProperty('os.name').toLowerCase().contains('linux')) {
+			throw new Exception('Sorry, we only support linux for automatic setup of the srs render environment. Please refer to doc/Development Setup.md!')
+		}
 	}
 	
 	workingDir "$projectDir/doc/Requirements Specification/"

--- a/deploy/Deploy Publish.sh
+++ b/deploy/Deploy Publish.sh
@@ -70,7 +70,7 @@ find . -maxdepth 1 \! \( -name .git -o -name . -o -name branches \) -exec rm -rf
 cp "$BASE/build/doc/Requirements Specification.pdf" .
 
 # README.md
-cp "$BASE/Default gh-pages README.md" ./README.md
+cp "$BASE/deploy/Default gh-pages README.md" ./README.md
 
 ###
 

--- a/deploy/Deploy Publish.sh
+++ b/deploy/Deploy Publish.sh
@@ -67,8 +67,10 @@ cd "$pubdir"
 find . -maxdepth 1 \! \( -name .git -o -name . -o -name branches \) -exec rm -rf {} \;
 
 # Requirements specification
+cp "$BASE/build/doc/Requirements Specification.pdf" .
 
-cp "$BASE/doc/Requirements Specification/Requirements Specification.pdf" .
+# README.md
+cp "$BASE/Default gh-pages README.md" ./README.md
 
 ###
 

--- a/doc/Development Setup.md
+++ b/doc/Development Setup.md
@@ -17,7 +17,7 @@ Required Eclipse plugins are:
 ## Building & Dependency Management
 The project is built using [Gradle](http://gradle.org/) 2.9. It can be downloaded [here](http://gradle.org/gradle-download/). Ubuntu users can use [this PPA](https://launchpad.net/~cwchien/+archive/ubuntu/gradle).
 
-We use the default commands: `gradle build` (or simply `gradle`) to test and build, `gradle test` to only run tests.
+We use the default commands: `gradle build` (or simply `gradle`) to test and build, `gradle test` to only run tests. Run `gradle tasks` to see all available tasks.
   
 ## Documentation
 

--- a/doc/Development Setup.md
+++ b/doc/Development Setup.md
@@ -14,6 +14,11 @@ Required Eclipse plugins are:
   * Close the projects `org.eclipse.gmt.modisco.java.edit`, `org.eclipse.gmt.modisco.omg.kdm.edit`, `org.somox.metrics.dsl.tests` and `org.somox.metrics.tests`
   * [Checkstyle] (http://eclipse-cs.sourceforge.net/#!/)
   
+## Building & Dependency Management
+The project is built using [Gradle](http://gradle.org/) 2.9. It can be downloaded [here](http://gradle.org/gradle-download/). Ubuntu users can use [this PPA](https://launchpad.net/~cwchien/+archive/ubuntu/gradle).
+
+We use the default commands: `gradle build` (or simply `gradle`) to test and build, `gradle test` to only run tests.
+  
 ## Documentation
 
 ### LyX

--- a/doc/Requirements Specification/README.md
+++ b/doc/Requirements Specification/README.md
@@ -39,15 +39,18 @@ A (small!) subset of the required LaTeX packages are:
   * Microtype (`microtype`)
   * Enumitem (`enumitem`)
   * Break citations (`breakcites`)
+  * xindy (`xindy`)
   
 If you care for the full list, look it up yourself in `sdqthesis.cls`.
-  
-On Ubuntu, all required packages can be installed by installing the`texlive-latex-base`, `texlive-latex-recommended`, `texlive-latex-extra`, `texlive-fonts-extra`, `texlive-bibtex-extra` and `texlive-lang-german` packages (you'll likely have them installed already):
+
+#### Ubuntu
+All required packages can be installed by installing the`texlive-latex-base`, `texlive-latex-recommended`, `texlive-latex-extra`, `texlive-fonts-extra`, `xindy`, `texlive-bibtex-extra` and `texlive-lang-german` debian packages (you'll likely have most of them installed already):
 ```
-sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-extra texlive-lang-german texlive-bibtex-extra
+sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-extra texlive-lang-german texlive-bibtex-extra xindy
 ```
 
-On Windows, you’ll likely use MiKTeX, which will install automatically all required packages automatically.
+#### Windows
+On Windows, you’ll likely use MiKTeX, which will install automatically all required packages automatically. However, you need to install Perl: [ActivePerl](http://www.activestate.com/activeperl/downloads). Make sure the checkbox "Add Perl to PATH", which appeares during the installation process, is checked.
 
 ## Usage
 Most of LyX’s usage is intuitive and should not require explanation. All documents are equiped with tons of notes and comments to make writing as easy as possible. Nevertheless, some points shall be outlined:
@@ -78,10 +81,12 @@ All Bibliography entries are stored in the file [Requirements Specification.bib]
  * Copy BiBTeX Code from sites like [Google Books](https://books.google.de/)
  
  
- #### Cite
- To cite use LyX: Insert -> Citation
+#### Cite
+To cite use LyX: Insert -> Citation
 
 ## Building
-Please note that the LyX preview builds will not contain the glossary. There seems to be no way to achieve that. To make a build containing the glossary, use the provided shell scripts:
- * For Linux: `render.sh`. You’ll need to install `xindy` (`sudo apt-get install xindy` on Debian).
- * For Windows: `render.bat`. You’ll need to install Perl: [ActivePerl](http://www.activestate.com/activeperl/downloads). Make sure the checkbox "Add Perl to PATH", which appeares during the installation process, is checked.
+Please note that the LyX preview builds will not contain the glossary. There seems to be no way to achieve that. To make a true build, run
+```
+gradle srs
+```
+in the Beagle project (“top”) directory. The SRS will be rendered to `build/doc/Requirements Specification.pdf`. It will also be built by `gradle build`.

--- a/doc/Requirements Specification/Render.bat
+++ b/doc/Requirements Specification/Render.bat
@@ -12,7 +12,7 @@ setlocal enableextensions
 
 IF %1=="" ( SET DEST="%cd%" ) ELSE ( SET DEST=%1 )
 IF %2=="" ( SET LOGDEST="%cd%\Render.log" ) ELSE ( SET LOGDEST=%2 )
-mkdir "%DEST%"
+mkdir %DEST%
 
 :: LyX executable. Add some logic here to search differen paths if your installation is elsewhere. 
 set LYX="C:\Program Files (x86)\LyX 2.1\bin\lyx.exe"
@@ -103,10 +103,10 @@ call :tee
 cd %OLDPWD%
 
 IF "%3"=="srs-only" (
-	xcopy /y %TMPDIR%\%FILENAME%.pdf "%DEST%"
+	xcopy /y %TMPDIR%\%FILENAME%.pdf %DEST%
 ) ELSE (
 	:: copy all rendered pdfs to save them
-	xcopy /s /y %TMPDIR%\*.pdf "%DEST%"
+	xcopy /s /y %TMPDIR%\*.pdf %DEST%
 )
 
 :: save the log

--- a/doc/Requirements Specification/Render.bat
+++ b/doc/Requirements Specification/Render.bat
@@ -10,9 +10,9 @@ setlocal enableextensions
 ::	2. the file to write the log to. Defaults to 'Render.sh' in the working directory
 ::	3. if "srs-only" is passed as 3. parameter, only the rendered 'Requirements Specification.pdf' will be created  
 
-IF %1=="" ( SET DEST="%cd%" ) ELSE ( SET DEST=%1 )
-IF %2=="" ( SET LOGDEST="%cd%\Render.log" ) ELSE ( SET LOGDEST=%2 )
-mkdir %DEST%
+IF [%1]==[] ( SET DEST="%cd%" ) ELSE ( SET DEST=%1 )
+IF [%2]==[] ( SET LOGDEST="%cd%\Render.log" ) ELSE ( SET LOGDEST=%2 )
+if not exist %DEST% mkdir %DEST%
 
 :: LyX executable. Add some logic here to search differen paths if your installation is elsewhere. 
 set LYX="C:\Program Files (x86)\LyX 2.1\bin\lyx.exe"
@@ -29,7 +29,7 @@ set sep=######################################
 call :GETTEMPNAME
 :: Create the folder and copy all contents in it
 mkdir %TMPDIR%
-xcopy . %TMPDIR% /e /i
+xcopy . %TMPDIR% /e /i /q
 set log="%TMPDIR%\Render.log"
 set tee="%TMPDIR%\tee"
 
@@ -41,7 +41,7 @@ cd %TMPDIR%
 :: The old log was copied in, remove it.
 if exist %log% del %log%
 :: remove old PDFs
-del /S *.pdf
+del /S *.pdf 1>nul
 
 
 :::::::::::::::

--- a/doc/Requirements Specification/Render.bat
+++ b/doc/Requirements Specification/Render.bat
@@ -1,6 +1,19 @@
 :: only print what we want to have printed
 @echo off
 
+:: see http://stackoverflow.com/questions/905226/mkdir-p-linux-windows
+setlocal enableextensions
+
+:: Requirements Specification render script.
+:: Parameters (all optional):
+::	1. the folder to copy the results to. Defaults to the working directory
+::	2. the file to write the log to. Defaults to 'Render.sh' in the working directory
+::	3. if "srs-only" is passed as 3. parameter, only the rendered 'Requirements Specification.pdf' will be created  
+
+IF %1=="" ( SET DEST="%cd%" ) ELSE ( SET DEST=%1 )
+IF %2=="" ( SET LOGDEST="%cd%\Render.log" ) ELSE ( SET LOGDEST=%2 )
+mkdir "%DEST%"
+
 :: LyX executable. Add some logic here to search differen paths if your installation is elsewhere. 
 set LYX="C:\Program Files (x86)\LyX 2.1\bin\lyx.exe"
 if not exist %LYX% set LYX="G:\Programme\LyX 2.1\bin\lyx.exe"
@@ -27,6 +40,8 @@ cd %TMPDIR%
 
 :: The old log was copied in, remove it.
 if exist %log% del %log%
+:: remove old PDFs
+del /S *.pdf
 
 
 :::::::::::::::
@@ -87,10 +102,18 @@ call :tee
 %drive%
 cd %OLDPWD%
 
-:: copy all rendered pdfs to save them
-xcopy /s /y %TMPDIR%\*.pdf .
+IF "%3"=="srs-only" (
+	xcopy /y %TMPDIR%\%FILENAME%.pdf "%DEST%"
+) ELSE (
+	:: copy all rendered pdfs to save them
+	xcopy /s /y %TMPDIR%\*.pdf "%DEST%"
+)
+
 :: save the log
-copy %log% . /y
+:: next line simulates 'dirname'
+for %%F in (%LOGDEST%) do set LOGDIRNAME=%%~dpF
+mkdir "%LOGDIRNAME%"
+copy /y %log% %LOGDEST%
 
 :: Delete the temporary folder, as we don't need the tons of files in it
 rmdir %TMPDIR% /s /q
@@ -152,3 +175,4 @@ call :tee
 goto :logerror
 
 :EOF
+endlocal

--- a/doc/Requirements Specification/Render.sh
+++ b/doc/Requirements Specification/Render.sh
@@ -107,7 +107,7 @@ pdflatex -interaction=nonstopmode -halt-on-error "$file.tex" | tee -a $log || er
 
 if [ "$3" = "srs-only" ]
 then
-	cp --parents -f "Requirements Specification.pdf" "$dest"
+	cp --parents -f "$file.pdf" "$dest"
 else
 	# copy all rendered pdfs to save them
 	find . -name '*.pdf' -exec cp --parents -f '{}' "$dest" \;

--- a/doc/Requirements Specification/Render.sh
+++ b/doc/Requirements Specification/Render.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 
+# Requirements Specification render script.
+# Parameters (all optional):
+#	1. the folder to copy the results to. Defaults to the working directory
+#	2. the file to write the log to. Defaults to 'Render.sh' in the working directory
+#	3. if "srs-only" is passed as 3. parameter, only the rendered 'Requirements Specification.pdf' will be created  
+
 file="Requirements Specification"
 
 # fail the script if any command fails
 set -e 
+
+# destination of the created files
+dest=${1:-$PWD}
+logdest=${2:-$PWD/Render.log}
+mkdir -p "$dest"
 
 # Copy everything to a new folder that we can savely delete
 tmpdir=`mktemp -d`
@@ -14,6 +25,8 @@ cd "$tmpdir"
 
 # The old log was copied in, remove it.
 rm -f $log
+# remove old PDFs
+find . -name '*.pdf' -exec rm -f '{}' \;
 
 # Called when one of the commands fails. Restores the PWD, writes the full log to stdout,
 # saves the log, prints a messages and exits.
@@ -92,11 +105,18 @@ pdflatex -interaction=nonstopmode -halt-on-error "$file.tex" | tee -a $log || er
 
 
 
+if [ "$3" = "srs-only" ]
+then
+	cp --parents -f "Requirements Specification.pdf" "$dest"
+else
+	# copy all rendered pdfs to save them
+	find . -name '*.pdf' -exec cp --parents -f '{}' "$dest" \;
+fi
 
-# copy all rendered pdfs to save them
-find . -name '*.pdf' -exec cp --parents -f '{}' "$OLDPWD" \;
 # save the log
-cp -f $log "$OLDPWD"
+mkdir -p "$(dirname "$logdest")"
+cp -f $log "$logdest"
+
 # Go back up
 cd "$OLDPWD"
 


### PR DESCRIPTION
Integrates our build process into gradle.

The SRS can now be built using `gradle srs`, which is now the preferred way. The result is put into the `build` folder. Although writing the render process as a native groovy task will surely increase its quality and maintainability (especially because we would no longer need two scripts), I don’t have the time to do that right now. I adapted the scripts to play nicely with gradle, but they should exactly behave like before if called with no arguments (which is now discouraged!). The build is lazy, meaning that they will only be executed if the input changed (which is important because because it will be executed on `gradle build`, too).

Travis now runs gradle, enabling us to do quality control on pull requests. Unfortunately, Travis does not support caching on the setup we use yet, so we will cannot profit of gradle’s “build on demand” features yet.

Just like the render scripts, the publish scripts should be migrated to gradle build scripts, too.