### PR TITLE
Adapted max. length of JavaDoc summary in Checkstyle.

### DIFF
--- a/src/test/Checkstyle.xml
+++ b/src/test/Checkstyle.xml
@@ -521,8 +521,8 @@
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
     <module name="SummaryJavadoc">
-      <property name="forbiddenSummaryFragments" value="^[^\.]{100,}.*$"/>
-      <message key="summary.javaDoc" value="Summary too long (max 100 letters)."/>
+      <property name="forbiddenSummaryFragments" value="^[^\.]{121,}.*$"/>
+      <message key="summary.javaDoc" value="Summary too long (max 120 letters)."/>
       <message key="summary.first.sentence" value="Javadoc incomplete: missing summary."/>
     </module>
   </module>


### PR DESCRIPTION
Fixes #332.