### PR TITLE
Let the web Task Break the Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ install:
   
 script:
   - gradle build qc || gradle build qc --info --stacktrace
+  - gradle web || gradle web --info --stacktrace
   
 after_script:
-  - gradle web || gradle web --info --stacktrace
   - ./buildSrc/src/deploy/bash/Deploy\ Web.sh
   
 after_success:

--- a/buildSrc/src/main/groovy/web/BeagleWebFilter.groovy
+++ b/buildSrc/src/main/groovy/web/BeagleWebFilter.groovy
@@ -33,7 +33,7 @@ abstract class BeagleWebFilter extends BaseFilterReader {
 			this.in = new StringReader(this.resultString)
 			setInitialized true
 		}
-		super.read()a
+		super.read()
 	}
 	
 	/**


### PR DESCRIPTION
As we noticed in #360, errors occuring when building the web presence should fail Travis. After this PR, Travis will still try to build the web presence, even if the build failded (to try and publish some report). But if `build` succeeds and `web` fails, Travis will now fail the entire build.

Depends on #360

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/361)
<!-- Reviewable:end -->
