### PR TITLE
Adapt the SVN Deploy Script to Gradle

### DIFF
--- a/buildSrc/src/deploy/bash/Deploy SVN.sh
+++ b/buildSrc/src/deploy/bash/Deploy SVN.sh
@@ -27,12 +27,12 @@ if [ "$TRAVIS_BRANCH" != "master" ]; then
 fi
 
 if [ -z ${SVN_USER:+1} ]; then
-	echo "We can't update the SVN because this no SVN_USER was provided."
+	echo "We can't update the SVN because no SVN_USER was provided."
 	exit 0
 fi
 
 if [ -z ${SVN_PASSWORD:+1} ]; then
-	echo "We can't update the SVN because this no SVN_PASSWORD was provided."
+	echo "We can't update the SVN because no SVN_PASSWORD was provided."
 	exit 0
 fi
 
@@ -42,8 +42,6 @@ GIT_URL="https://github.com/Beagle-PSE/Beagle.git"
 
 # Set up our environment
 SVN=../svn
-GITSUB=$SVN/repository
-GENERATEDSUB=$SVN/generated
 BASE=$PWD
 rm -rf $SVN
 mkdir -p $SVN
@@ -51,23 +49,20 @@ mkdir -p $SVN
 cd $SVN
 
 # Check out from SVN
-svn checkout $SVN_URL $SVN --username $SVN_USER --password "$SVN_PASSWORD" --non-interactive --quiet
+svn checkout $SVN_URL $SVN --username $SVN_USER --password "$SVN_PASSWORD" --non-interactive --quiet  > /dev/null 2>&1
 
 # Remove all content - except the svn files
 find . -maxdepth 1 \! \( -name .svn -o -name . \) -exec rm -rf {} \;
 
-# Set up the repository
-git clone $GIT_URL $GITSUB --quiet
-# Remove the .git folder
-rm -rf $GITSUB/.git
+# Copy in the files
+cp -r "$BASE"/* .
 
-
-mkdir -p $GENERATEDSUB
-cp "$BASE/doc/Requirements Specification/Requirements Specification.pdf" $GENERATEDSUB
+# Remove files that are not needed
+rm -rf build/tmp build/classes
 
 svn add . --force --non-interactive --quiet
 
-svn commit -m "Automatic Travis update from $GIT_URL" --username $SVN_USER --password "$SVN_PASSWORD" --non-interactive --quiet
+svn commit -m "Automatic Travis update from $GIT_URL" --username $SVN_USER --password "$SVN_PASSWORD" --non-interactive --quiet  > /dev/null 2>&1
 
 cd $BASE
 

--- a/buildSrc/src/deploy/bash/Deploy SVN.sh
+++ b/buildSrc/src/deploy/bash/Deploy SVN.sh
@@ -58,7 +58,7 @@ find . -maxdepth 1 \! \( -name .svn -o -name . \) -exec rm -rf {} \;
 cp -r "$BASE"/* .
 
 # Remove files that are not needed
-rm -rf build/tmp build/classes
+rm -rf build/tmp build/classes .git .gradle
 
 svn add . --force --non-interactive --quiet
 


### PR DESCRIPTION
Until now, the SVN deploy script created a directory structure like this:

```
|
|-- repository (a clone of our repository)
|-- generated (a folder where we manually copied our generated files to)
```

After this PR, we will simpld deploy the directory structure like its left after running gradle. All generated files will be found in the `build` folder.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/364)
<!-- Reviewable:end -->
