### PR TITLE
Design frame document.

### DIFF
--- a/doc/Design/.gitignore
+++ b/doc/Design/.gitignore
@@ -1,0 +1,1 @@
+Design.pdf

--- a/doc/Design/Design.lyx
+++ b/doc/Design/Design.lyx
@@ -50,7 +50,7 @@
 
 % Set the PDF metadata
 \hypersetup{
-    pdftitle={Beagle --- Design & Architecturen},
+    pdftitle={Beagle --- Design and Architecture},
     pdfsubject={Beagle is a tool for automatic dynamic source code analysis in order to find resource demands of component based software’s components’ internal actions.},
     pdfauthor={Annika Berger, Joshua Gleitze, Roman Langrehr, Christoph Michelbach, Ansgar Spiegler, Michael Vogt},
     pdfkeywords={component based software, dynamic analysis, reverse engeneering, resource demands, SoMoX, Beagle, Palladio, Eclipse, Kieker},
@@ -146,7 +146,7 @@ Beagle
 \end_layout
 
 \begin_layout Subtitle
-Design & Architecture
+Design and Architecture
 \end_layout
 
 \begin_layout Date

--- a/doc/Design/Design.lyx
+++ b/doc/Design/Design.lyx
@@ -1,0 +1,416 @@
+#LyX 2.1 created this file. For more info see http://www.lyx.org/
+\lyxformat 474
+\begin_document
+\begin_header
+\textclass sdqthesis
+\begin_preamble
+% Rewrite the title template to fit our needs (as we're not writing a thesis,
+% some things simply make no sense.
+\renewcommand{\settitle}{%
+    \publishers{%
+    \large
+    \iflanguage{english}
+        {at the Department of Informatics}%
+        {an der Fakultät für Informatik}\\
+    \theinstitute\\[2em]
+    \begin{tabular}{l l}
+        \iflanguage{english}{Reviewer}{Erstgutachter}: & \thereviewerone\\
+        \iflanguage{english}{Advisor}{Betreuender Mitarbeiter}: &  \theadvisorone\\
+        % if there is no second advisor, do not output this line
+        \ifthenelse{\equal{\theadvisortwo}{}}{}{%
+            \iflanguage{english}{Second advisor}{Zweiter betreuender Mitarbeiter}: & \theadvisortwo\\
+        }
+    \end{tabular}
+    }
+}
+
+% Metadata
+\reviewerone{Jun.-Prof. Dr.-Ing. Anne Koziolek}
+\advisorone{M.Sc. Axel Busch}
+\advisortwo{M.Sc. Michael Langhammer}
+\settitle
+
+% \todo is deprecated!
+\renewcommand\todo{\errmessage{TODO tags are not supported anymore. Please use GitHub issues!}}
+
+% Packages for floating images
+\usepackage{graphicx}
+\usepackage{grffile}
+\usepackage[all]{hypcap}
+
+% Make floats work batter with Koma book
+\usepackage{scrhack}
+
+% No page numbers for the title pages
+\pagenumbering{gobble}
+
+% Adding package bookmark improves bookmarks handling.
+% More features and faster updated bookmarks.
+\usepackage{bookmark}
+
+% Set the PDF metadata
+\hypersetup{
+    pdftitle={Beagle --- Design & Architecturen},
+    pdfsubject={Beagle is a tool for automatic dynamic source code analysis in order to find resource demands of component based software’s components’ internal actions.},
+    pdfauthor={Annika Berger, Joshua Gleitze, Roman Langrehr, Christoph Michelbach, Ansgar Spiegler, Michael Vogt},
+    pdfkeywords={component based software, dynamic analysis, reverse engeneering, resource demands, SoMoX, Beagle, Palladio, Eclipse, Kieker},
+    pdfcreator={LyX, pdflatex},
+    pdfproducer={LaTeX},
+    hidelinks,
+    breaklinks
+}
+\end_preamble
+\options english,final
+\use_default_options true
+\begin_modules
+enumitem
+\end_modules
+\maintain_unincluded_children false
+\language british
+\language_package auto
+\inputencoding utf8
+\fontencoding global
+\font_roman default
+\font_sans default
+\font_typewriter default
+\font_math auto
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100
+\font_tt_scale 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\float_placement tph
+\paperfontsize default
+\spacing single
+\use_hyperref false
+\pdf_bookmarks true
+\pdf_bookmarksnumbered false
+\pdf_bookmarksopen false
+\pdf_bookmarksopenlevel 1
+\pdf_breaklinks true
+\pdf_pdfborder true
+\pdf_colorlinks false
+\pdf_backref false
+\pdf_pdfusetitle true
+\papersize default
+\use_geometry true
+\use_package amsmath 2
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date true
+\justification true
+\use_refstyle 1
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 2
+\paperpagestyle default
+\listings_params "basicstyle={\ttfamily}"
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Title
+Beagle
+\end_layout
+
+\begin_layout Subtitle
+Design & Architecture
+\end_layout
+
+\begin_layout Date
+10th of January 2016
+\end_layout
+
+\begin_layout Author
+Annika Berger, Joshua Gleitze, Roman Langrehr,
+\begin_inset Newline newline
+\end_inset
+
+Christoph Michelbach, Ansgar Spiegler, Michael Vogt
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+% Start the page numbering in roman numbers
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+setcounter{page}{1}
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+pagenumbering{roman}
+\end_layout
+
+\begin_layout Plain Layout
+
+\end_layout
+
+\begin_layout Plain Layout
+
+% Don't add blank pages in the toc section
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+KOMAoptions{open=any}
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+% If ever needed, describe separation hints here.
+\end_layout
+
+\begin_layout Plain Layout
+
+% For more details, see  http://en.wikibooks.org/wiki/LaTeX/Text_Formatting#Hyphen
+ation
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+hyphenation{me-ta-mo-del} 
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+% bookmark for toc
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+pdfbookmark[section]{
+\backslash
+contentsname}{toc}
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset CommandInset toc
+LatexCommand tableofcontents
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset Newpage newpage
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+% assures we have correct links for the list of figures
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+phantomsection
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+addcontentsline{toc}{chapter}{
+\backslash
+listfigurename}
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset FloatList figure
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+% Start the main document (includes new numbering in arabic numbers)
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+mainmatter
+\end_layout
+
+\begin_layout Plain Layout
+
+\end_layout
+
+\begin_layout Plain Layout
+
+% Enabling to only start chapters on the right again.
+\end_layout
+
+\begin_layout Plain Layout
+
+
+\backslash
+KOMAoptions{open=right}
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset CommandInset include
+LatexCommand input
+preview true
+filename "Parts/Architectual Overview.lyx"
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset CommandInset include
+LatexCommand input
+preview true
+filename "Parts/Component Beagle Core.lyx"
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset CommandInset include
+LatexCommand input
+preview true
+filename "Parts/Component Beagle GUI.lyx"
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset CommandInset include
+LatexCommand input
+preview true
+filename "Parts/Component Measurement Tool.lyx"
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset CommandInset include
+LatexCommand input
+preview true
+filename "Parts/Component Result Analyser.lyx"
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset CommandInset include
+LatexCommand input
+preview true
+filename "Parts/Component Final Judge.lyx"
+
+\end_inset
+
+
+\end_layout
+
+\end_body
+\end_document

--- a/doc/Design/Parts/Architectual Overview.lyx
+++ b/doc/Design/Parts/Architectual Overview.lyx
@@ -1,0 +1,115 @@
+#LyX 2.1 created this file. For more info see http://www.lyx.org/
+\lyxformat 474
+\begin_document
+\begin_header
+\textclass sdqthesis
+\use_default_options true
+\master ../Requirements Specification.lyx
+\maintain_unincluded_children false
+\language british
+\language_package default
+\inputencoding utf8
+\fontencoding global
+\font_roman default
+\font_sans default
+\font_typewriter default
+\font_math auto
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100
+\font_tt_scale 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\spacing single
+\use_hyperref false
+\papersize default
+\use_geometry true
+\use_package amsmath 2
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Chapter
+Architectural Overview
+\end_layout
+
+\begin_layout Standard
+\begin_inset Note Note
+status open
+
+\begin_layout Plain Layout
+Architectual Overview 
+\end_layout
+
+\begin_layout Plain Layout
+- Overview of the whole system
+\end_layout
+
+\begin_layout Plain Layout
+- Description of components’ interaction
+\end_layout
+
+\begin_layout Plain Layout
+- Communication between Beagle and external tools
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Section
+Overview of the entire system
+\end_layout
+
+\begin_layout Section
+Components’ interaction
+\end_layout
+
+\begin_layout Section
+Communication between Beagle and external tools
+\end_layout
+
+\end_body
+\end_document

--- a/doc/Design/Parts/Component Beagle Core.lyx
+++ b/doc/Design/Parts/Component Beagle Core.lyx
@@ -1,0 +1,139 @@
+#LyX 2.1 created this file. For more info see http://www.lyx.org/
+\lyxformat 474
+\begin_document
+\begin_header
+\textclass sdqthesis
+\use_default_options true
+\master ../Design.lyx
+\maintain_unincluded_children false
+\language british
+\language_package default
+\inputencoding utf8
+\fontencoding global
+\font_roman default
+\font_sans default
+\font_typewriter default
+\font_math auto
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100
+\font_tt_scale 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\spacing single
+\use_hyperref false
+\papersize default
+\use_geometry true
+\use_package amsmath 2
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Chapter
+Component: Beagle Core
+\end_layout
+
+\begin_layout Standard
+\begin_inset Note Note
+status open
+
+\begin_layout Plain Layout
+Component: Beagle Core
+\end_layout
+
+\begin_layout Plain Layout
+- Describe most important classes
+\end_layout
+
+\begin_layout Plain Layout
+- Give reasons for chosen design
+\end_layout
+
+\begin_layout Plain Layout
+-Describe chosen design patterns
+\end_layout
+
+\begin_layout Plain Layout
+- Describe Evaluable Expressions
+\end_layout
+
+\begin_layout Plain Layout
+- Describe conversion from and to Palladio
+\end_layout
+
+\begin_layout Plain Layout
+
+\end_layout
+
+\begin_layout Plain Layout
+List all associated packages
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Section
+The most important classes
+\end_layout
+
+\begin_layout Section
+Reasons for chosen design
+\end_layout
+
+\begin_layout Section
+Chosen design patterns
+\end_layout
+
+\begin_layout Section
+Evaluable Expressions
+\end_layout
+
+\begin_layout Section
+Conversion from and to Palladio
+\end_layout
+
+\end_body
+\end_document

--- a/doc/Design/Parts/Component Beagle GUI.lyx
+++ b/doc/Design/Parts/Component Beagle GUI.lyx
@@ -1,0 +1,119 @@
+#LyX 2.1 created this file. For more info see http://www.lyx.org/
+\lyxformat 474
+\begin_document
+\begin_header
+\textclass sdqthesis
+\use_default_options true
+\master ../Design.lyx
+\maintain_unincluded_children false
+\language british
+\language_package default
+\inputencoding utf8
+\fontencoding global
+\font_roman default
+\font_sans default
+\font_typewriter default
+\font_math auto
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100
+\font_tt_scale 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\spacing single
+\use_hyperref false
+\papersize default
+\use_geometry true
+\use_package amsmath 2
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Chapter
+Component Beagle GUI
+\end_layout
+
+\begin_layout Standard
+\begin_inset Note Note
+status open
+
+\begin_layout Plain Layout
+Component: Beagle GUI
+\end_layout
+
+\begin_layout Plain Layout
+- Describe most important classes
+\end_layout
+
+\begin_layout Plain Layout
+- Give reasons for chosen design
+\end_layout
+
+\begin_layout Plain Layout
+- Describe chosen design patterns (Model-View-Controller!)
+\end_layout
+
+\begin_layout Plain Layout
+List all associated packages
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Section
+The most important classes
+\end_layout
+
+\begin_layout Section
+Reasons for chosen design
+\end_layout
+
+\begin_layout Section
+Chosen design patterns
+\end_layout
+
+\end_body
+\end_document

--- a/doc/Design/Parts/Component Beagle GUI.lyx
+++ b/doc/Design/Parts/Component Beagle GUI.lyx
@@ -71,7 +71,7 @@
 \begin_body
 
 \begin_layout Chapter
-Component Beagle GUI
+Component: Beagle GUI
 \end_layout
 
 \begin_layout Standard

--- a/doc/Design/Parts/Component Final Judge.lyx
+++ b/doc/Design/Parts/Component Final Judge.lyx
@@ -71,7 +71,7 @@
 \begin_body
 
 \begin_layout Chapter
-Component Final Judge
+Component: Final Judge
 \end_layout
 
 \begin_layout Standard

--- a/doc/Design/Parts/Component Final Judge.lyx
+++ b/doc/Design/Parts/Component Final Judge.lyx
@@ -1,0 +1,119 @@
+#LyX 2.1 created this file. For more info see http://www.lyx.org/
+\lyxformat 474
+\begin_document
+\begin_header
+\textclass sdqthesis
+\use_default_options true
+\master ../Design.lyx
+\maintain_unincluded_children false
+\language british
+\language_package default
+\inputencoding utf8
+\fontencoding global
+\font_roman default
+\font_sans default
+\font_typewriter default
+\font_math auto
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100
+\font_tt_scale 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\spacing single
+\use_hyperref false
+\papersize default
+\use_geometry true
+\use_package amsmath 2
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Chapter
+Component Final Judge
+\end_layout
+
+\begin_layout Standard
+\begin_inset Note Note
+status open
+
+\begin_layout Plain Layout
+Component: Final Judge
+\end_layout
+
+\begin_layout Plain Layout
+- Give reasons for the generally chosen design
+\end_layout
+
+\begin_layout Plain Layout
+- Describe the Final Judge that will be implement in the first iteration
+ (averaging Final Judge)
+\end_layout
+
+\begin_layout Plain Layout
+List all associated packages
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Section
+Reasons for chosen design
+\end_layout
+
+\begin_layout Section
+\begin_inset Quotes eld
+\end_inset
+
+Averaging
+\begin_inset Quotes erd
+\end_inset
+
+ Final Judge
+\end_layout
+
+\end_body
+\end_document

--- a/doc/Design/Parts/Component Measurement Tool.lyx
+++ b/doc/Design/Parts/Component Measurement Tool.lyx
@@ -71,7 +71,7 @@
 \begin_body
 
 \begin_layout Chapter
-Component Measurement Tool
+Component: Measurement Tool
 \end_layout
 
 \begin_layout Standard

--- a/doc/Design/Parts/Component Measurement Tool.lyx
+++ b/doc/Design/Parts/Component Measurement Tool.lyx
@@ -1,0 +1,111 @@
+#LyX 2.1 created this file. For more info see http://www.lyx.org/
+\lyxformat 474
+\begin_document
+\begin_header
+\textclass sdqthesis
+\use_default_options true
+\master ../Design.lyx
+\maintain_unincluded_children false
+\language british
+\language_package default
+\inputencoding utf8
+\fontencoding global
+\font_roman default
+\font_sans default
+\font_typewriter default
+\font_math auto
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100
+\font_tt_scale 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\spacing single
+\use_hyperref false
+\papersize default
+\use_geometry true
+\use_package amsmath 2
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Chapter
+Component Measurement Tool
+\end_layout
+
+\begin_layout Standard
+\begin_inset Note Note
+status open
+
+\begin_layout Plain Layout
+Component: Measurement Tool
+\end_layout
+
+\begin_layout Plain Layout
+- Give reasons for the generally chosen design
+\end_layout
+
+\begin_layout Plain Layout
+- Describe adapter to Kieker
+\end_layout
+
+\begin_layout Plain Layout
+List all associated packages
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Section
+Reasons for chosen design
+\end_layout
+
+\begin_layout Section
+Adapter to Kieker
+\end_layout
+
+\end_body
+\end_document

--- a/doc/Design/Parts/Component Result Analyser.lyx
+++ b/doc/Design/Parts/Component Result Analyser.lyx
@@ -1,0 +1,103 @@
+#LyX 2.1 created this file. For more info see http://www.lyx.org/
+\lyxformat 474
+\begin_document
+\begin_header
+\textclass sdqthesis
+\use_default_options true
+\master ../Design.lyx
+\maintain_unincluded_children false
+\language british
+\language_package default
+\inputencoding utf8
+\fontencoding global
+\font_roman default
+\font_sans default
+\font_typewriter default
+\font_math auto
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100
+\font_tt_scale 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\spacing single
+\use_hyperref false
+\papersize default
+\use_geometry true
+\use_package amsmath 2
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Chapter
+Component: Result Analyser
+\end_layout
+
+\begin_layout Standard
+\begin_inset Note Note
+status open
+
+\begin_layout Plain Layout
+Component: Result Analyser
+\end_layout
+
+\begin_layout Plain Layout
+- Give reasons for the generally chosen design
+\end_layout
+
+\begin_layout Plain Layout
+List all associated packages
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Section
+Reasons for chosen design
+\end_layout
+
+\end_body
+\end_document


### PR DESCRIPTION
Fixes #368 

I added some sample *section* headlines, according to the TOC. They can be changed, of course.

I think
>      * Description of components’ interaction
 * Communication between Core and external Components

was duplicated. (Maybe it was a mistake). I changed the second point to `Communication between Beagle and external tools` and made it a section in the first chapter.

Here is the [rendered document](https://www.dropbox.com/s/t7mb67vogll95x8/Design.pdf?dl=0).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/378)
<!-- Reviewable:end -->
