### PR TITLE
Fix Image Heights to Make the SRS Render Without UML PDFs

### DIFF
--- a/doc/Requirements Specification/Parts/Application.lyx
+++ b/doc/Requirements Specification/Parts/Application.lyx
@@ -198,6 +198,8 @@ status open
 \begin_inset Graphics
 	filename UML Diagrams/Reengineering.uxf.pdf
 	width 90text%
+	height 100pheight%
+	keepAspectRatio
 
 \end_inset
 
@@ -357,6 +359,8 @@ status open
 \begin_inset Graphics
 	filename UML Diagrams/Development.uxf.pdf
 	width 90text%
+	height 100pheight%
+	keepAspectRatio
 
 \end_inset
 
@@ -518,6 +522,8 @@ status open
 \begin_inset Graphics
 	filename UML Diagrams/Prototyp.uxf.pdf
 	width 90text%
+	height 100pheight%
+	keepAspectRatio
 
 \end_inset
 
@@ -651,6 +657,8 @@ status open
 \begin_inset Graphics
 	filename UML Diagrams/Validation.uxf.pdf
 	width 90text%
+	height 100pheight%
+	keepAspectRatio
 
 \end_inset
 

--- a/doc/Requirements Specification/Parts/Environment.lyx
+++ b/doc/Requirements Specification/Parts/Environment.lyx
@@ -327,6 +327,8 @@ status open
 \begin_inset Graphics
 	filename UML Diagrams/Component.uxf.pdf
 	width 100text%
+	height 100pheight%
+	keepAspectRatio
 
 \end_inset
 

--- a/doc/Requirements Specification/Parts/Purpose.lyx
+++ b/doc/Requirements Specification/Parts/Purpose.lyx
@@ -999,6 +999,8 @@ status open
 \begin_inset Graphics
 	filename UML Diagrams/Use Cases.uxf.pdf
 	width 100text%
+	height 100pheight%
+	keepAspectRatio
 
 \end_inset
 


### PR DESCRIPTION
fixes #377 

I set the height to the page’s height. This is a natural limitation anyway ;)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/384)
<!-- Reviewable:end -->
