### PR TITLE
Fixed Spelling mistake in UML Diagram

### DIFF
--- a/doc/Design/Packages/Beagle Core/Evaluable Expression.uml
+++ b/doc/Design/Packages/Beagle Core/Evaluable Expression.uml
@@ -13,7 +13,7 @@
       </ownedParameter>
     </ownedOperation>
   </packagedElement>
-  <packagedElement xmi:type="uml:Interface" xmi:id="_3MNrYKHnEeWB_pi2tzIUuQ" name="Evaluatable Expression Visitor">
+  <packagedElement xmi:type="uml:Interface" xmi:id="_3MNrYKHnEeWB_pi2tzIUuQ" name="Evaluable Expression Visitor">
     <ownedOperation xmi:type="uml:Operation" xmi:id="_LxiJkKHoEeWB_pi2tzIUuQ" name="visit">
       <ownedParameter xmi:type="uml:Parameter" xmi:id="_QP6ZYKHoEeWB_pi2tzIUuQ" type="_WQiUgKHnEeWB_pi2tzIUuQ" effect="update"/>
     </ownedOperation>


### PR DESCRIPTION
UML Diagram contained Evaluatable Expression Visitor instead of Evaluable Expression Visitor

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/427)
<!-- Reviewable:end -->
