### PR TITLE
Javadoc: Don’t print timestamp comment

### DIFF
--- a/Documentation/buildSrc/src/tasks/gradle/10 javadoc.gradle
+++ b/Documentation/buildSrc/src/tasks/gradle/10 javadoc.gradle
@@ -49,6 +49,7 @@ task javadoc(type: Javadoc) {
 	classpath = classpath javadocSubprojects
 	options.overview "$projectDir/src/javadoc/html/Overview.html"
 	options.encoding = "UTF-8"
+	options.noTimestamp = true
 }
  
 def rendersrc = fileTree("$projectDir/src").include('common/**').include('javadoc/lyx/**')


### PR DESCRIPTION
The Javadoc default doclet per default prints a timestamp in a HTML comment (it doesn’t even use a metatag!).

When deploying to SVN or gh-pages, this leads to a lot of unnecessarily updated files. I thus disabled it to produce less data and maybe even speedup the SVN deployment.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/620)
<!-- Reviewable:end -->
