### PR TITLE
Checkstyle: Fix for Update

### DIFF
--- a/config/checkstyle/Checkstyle Prototype.xml
+++ b/config/checkstyle/Checkstyle Prototype.xml
@@ -207,7 +207,7 @@
     <module name="NoWhitespaceAfter">
       <property name="severity" value="warning"/>
       <property name="allowLineBreaks" value="false"/>
-      <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS,GENERIC_START"/>
+      <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
     </module>
     <module name="NoWhitespaceBefore">
       <property name="severity" value="warning"/>

--- a/config/checkstyle/Checkstyle Test.xml
+++ b/config/checkstyle/Checkstyle Test.xml
@@ -208,7 +208,7 @@
     <module name="NoWhitespaceAfter">
       <property name="severity" value="warning"/>
       <property name="allowLineBreaks" value="false"/>
-      <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS,GENERIC_START"/>
+      <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
     </module>
     <module name="NoWhitespaceBefore">
       <property name="severity" value="warning"/>

--- a/config/checkstyle/Checkstyle.xml
+++ b/config/checkstyle/Checkstyle.xml
@@ -207,7 +207,7 @@
     <module name="NoWhitespaceAfter">
       <property name="severity" value="warning"/>
       <property name="allowLineBreaks" value="false"/>
-      <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS,GENERIC_START"/>
+      <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
     </module>
     <module name="NoWhitespaceBefore">
       <property name="severity" value="warning"/>


### PR DESCRIPTION
As we already know, the folks at Checkstyle don’t care about backwards compatibility at all. After the last update, the plugin fails because it suddenly doesn’t know `GENERIC_START` anymore. This PR fixes it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/625)
<!-- Reviewable:end -->
