### PR TITLE
Fix Code Coverage Problem

### DIFF
--- a/buildSrc/src/tasks/gradle/20 qc.gradle
+++ b/buildSrc/src/tasks/gradle/20 qc.gradle
@@ -22,7 +22,26 @@ configure(javaSubprojects) {
 			xml.enabled true
 			html.destination "$buildDir/reports/jacoco/html"
 		}
-	}
+		
+		// exclude all source files marked by 'COVERAGE:OFF' or 'JACOCO:OFF'
+		afterEvaluate {
+			classDirectories = files(classDirectories.files.collect { classDir ->
+				def base = classDir.toPath()
+	            def tree = fileTree(classDir)
+	            tree.exclude { spec ->
+	            	def classPath = base.relativize(spec.file.toPath()).toString()
+
+	            	if (classPath.endsWith('.class')) {
+	            		def sourcePath = classPath - '.class' + '.java'
+	            		def sourceFile = file("$project.projectDir/src/main/java/$sourcePath")
+	            		return sourceFile.text.contains('COVERAGE:OFF') || sourceFile.text.contains('JACOCO:OFF')
+	            	}
+	            	return false
+	            }
+	            return tree
+	        })
+		}
+	}	
 	
 	task verifyNoCheckstyleWarnings(dependsOn: check) {
 		description 'Throws if checkstyle warnings were found in a previous checkstyle run.'


### PR DESCRIPTION
fix #616 

@jGleitz adapted the gradle task for test coverage so that we can use the labels "JACOCO:OFF" and "COVERAGE:OFF" to define that a class does not have to be tested yet.

I added all Labels to the java classes in #602. Please make sure you remove them when implementing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/630)
<!-- Reviewable:end -->
