### PR TITLE
Fix the Completely Broken NullHandlingMatchers

### DIFF
--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/NullHandlingMatchers.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/NullHandlingMatchers.java
@@ -2,6 +2,7 @@ package de.uka.ipd.sdq.beagle.core.testutil;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -31,6 +32,11 @@ public final class NullHandlingMatchers {
 	private static final Matcher<ThrowingMethod> THROWS_NPE = throwsException(NullPointerException.class);
 
 	/**
+	 * A matcher matching if a method throws a IllegalArgumentException.
+	 */
+	private static final Matcher<ThrowingMethod> THROWS_IAE = throwsException(IllegalArgumentException.class);
+
+	/**
 	 * This is a utility class and not meant to be instantiated.
 	 */
 	private NullHandlingMatchers() {
@@ -39,8 +45,8 @@ public final class NullHandlingMatchers {
 	/**
 	 * Creates a matcher that matches if the examined lambda does no accept {@code null}
 	 * in its input values. The examined lambda takes an array as only argument and is
-	 * expected to throw a {@link NullPointerException} if this array contains
-	 * {@code null} or is {@code null} itself.
+	 * expected to throw a {@link NullPointerException} if this array is {@code null} and
+	 * an {@link IllegalArgumentException} if the array contains {@code null}.
 	 *
 	 * @param <CONSUMED_TYPE> type of the elements of the array the examined lambda takes
 	 *            as its argument.
@@ -52,6 +58,9 @@ public final class NullHandlingMatchers {
 		final CONSUMED_TYPE[] testValues) {
 		final NotAcceptingNullInListMatcher<CONSUMED_TYPE> listMatcher =
 			THIZ.new NotAcceptingNullInListMatcher<>(Arrays.asList(testValues));
+		// hack to get an empty array of CONSUMED_TYPE without SurpressWarnings
+		final CONSUMED_TYPE[] copyInstance = ArrayUtils.clone(testValues);
+		ArrayUtils.removeElements(copyInstance, copyInstance);
 
 		return new TypeSafeDiagnosingMatcher<Consumer<CONSUMED_TYPE[]>>() {
 
@@ -61,10 +70,9 @@ public final class NullHandlingMatchers {
 			}
 
 			@Override
-			protected boolean matchesSafely(final Consumer<CONSUMED_TYPE[]> consumer,
+			protected boolean matchesSafely(final Consumer<CONSUMED_TYPE[]> item,
 				final Description mismatchDescription) {
-				return listMatcher.matchesSafely(
-					(final Collection<CONSUMED_TYPE> inputCollection) -> consumer.accept(inputCollection.toArray(null)),
+				return listMatcher.matchesSafely((list) -> item.accept(list.toArray(copyInstance)),
 					mismatchDescription);
 			}
 		};
@@ -73,8 +81,8 @@ public final class NullHandlingMatchers {
 	/**
 	 * Creates a matcher that matches if the examined lambda does no accept {@code null}
 	 * in its input values. The examined lambda takes a collection as only argument and is
-	 * expected to throw a {@link NullPointerException} if this collection contains
-	 * {@code null} or is {@code null} itself.
+	 * expected to throw a {@link NullPointerException} if this collection is {@code null}
+	 * and an {@link IllegalArgumentException} if the collection contains {@code null}.
 	 *
 	 * @param <CONSUMED_TYPE> type of the elements of the collection the examined lambda
 	 *            takes as its argument.
@@ -119,13 +127,12 @@ public final class NullHandlingMatchers {
 	/**
 	 * A matcher that matches if the examined lambda does no accept {@code null} in its
 	 * input values. The examined lambda takes a list as only argument and is expected to
-	 * throw a {@link NullPointerException} if this collection contains {@code null} or is
-	 * {@code null} itself.
+	 * throw a {@link NullPointerException} if this list is {@code null} and a
+	 * {@link IllegalArgumentException} if the list contains {@code null}.
 	 *
 	 * @author Joshua Gleitze
 	 * @param <CONSUMED_TYPE> type of the elements of the array the examined lambda takes
 	 *            as its argument.
-	 * @see NullHandlingMatchers#notAcceptingNull(Object[])
 	 */
 	private final class NotAcceptingNullInListMatcher<CONSUMED_TYPE>
 		extends TypeSafeDiagnosingMatcher<Consumer<Collection<CONSUMED_TYPE>>> {
@@ -156,7 +163,15 @@ public final class NullHandlingMatchers {
 		@Override
 		protected boolean matchesSafely(final Consumer<Collection<CONSUMED_TYPE>> consumer,
 			final Description mismatchDescription) {
-			boolean matchedAll = true;
+			ThrowingMethod nullApplied;
+
+			// feed null
+			nullApplied = () -> consumer.accept(null);
+			if (!THROWS_NPE.matches(nullApplied)) {
+				THROWS_NPE.describeMismatch(nullApplied, mismatchDescription);
+				mismatchDescription.appendText(" when passing null as argument");
+				return false;
+			}
 
 			// insert null at start, middle and end
 			final List<List<CONSUMED_TYPE>> inputsWithNull = Arrays.asList(withNull(this.testValues, 0),
@@ -164,21 +179,15 @@ public final class NullHandlingMatchers {
 
 			// feed the lists containing null
 			for (final List<CONSUMED_TYPE> testInputsWithNull : inputsWithNull) {
-				if (!THROWS_NPE.matches((ThrowingMethod) () -> consumer.accept(testInputsWithNull))) {
-					THROWS_NPE.describeMismatch(consumer, mismatchDescription);
+				nullApplied = () -> consumer.accept(testInputsWithNull);
+				if (!THROWS_IAE.matches(nullApplied)) {
+					THROWS_IAE.describeMismatch(nullApplied, mismatchDescription);
 					mismatchDescription.appendText(" when passing null in the argument");
-					matchedAll = false;
+					return false;
 				}
 			}
 
-			// feed null
-			if (!THROWS_NPE.matches((ThrowingMethod) () -> consumer.accept(null))) {
-				THROWS_NPE.describeMismatch(consumer, mismatchDescription);
-				mismatchDescription.appendText(" when passing null as argument");
-				matchedAll = false;
-			}
-
-			return matchedAll;
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
I don’t know what I did when writing `NullHandlingMatchers`, but it’s totally buggy. This PR should fix that.

 * expects now an `IllegalArgumentException` if there’s `null` *in* the input, because that’s what the Apache Commons do
 * creates correct error messages
 * doesn’t throw exceptions itself

Sorry for fucking up that bad!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/642)
<!-- Reviewable:end -->
