### PR TITLE
Speed Up Update Site Download

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,7 +13,7 @@ allprojects {
 
 	buildDir = rootProject.buildDir
 	
-	fileTree("$projectDir/src/main/groovy").include('**dependencies.gradle').each { file ->
+	fileTree("$projectDir/src/main/groovy").include('**/dependencies.gradle').each { file ->
 		project.apply from: file
 	}
 	

--- a/buildSrc/src/main/groovy/DownloadUpdateSites.groovy
+++ b/buildSrc/src/main/groovy/DownloadUpdateSites.groovy
@@ -26,6 +26,10 @@ public class DownloadUpdateSites implements Plugin<Project> {
 	void apply(Project project) {
 		project.extensions.create "updatesites", UpdateSitesConfigurationExtension, this
 		this.project = project
+		project.afterEvaluate {
+			downloadSites()
+			tellWuff()
+		}
 	}
 	
 	/**
@@ -43,9 +47,25 @@ public class DownloadUpdateSites implements Plugin<Project> {
 					// unpuzzle’s dummy checksum
 					updateSite.checksumFile.text = 'deadbea1'
 				}
+				
 			}
 		}
     }
+    
+    /**
+     * Tells wuff about the sites
+     */
+    def tellWuff() {
+    	this.sites.each { updateSite ->
+			project.wuff {
+				eclipseVersion(selectedEclipseVersion) {
+					sources {
+						source "file://$updateSite.destinationFolder"
+					}
+				}
+			}
+		}
+	}
     
     /**
      * Adds {@code url} to the sites to be downloaded. 
@@ -62,15 +82,6 @@ public class DownloadUpdateSites implements Plugin<Project> {
 		
 		// queue the site to be downloaded
 		this.sites.add new UpdateSite(url: new URL(url), destinationFolder: destinationDir, checksumFile: checksumFile)
-		
-		// tell wuff about the downloaded folder
-		project.wuff {
-			eclipseVersion(selectedEclipseVersion) {
-				sources {
-					source "file://$destinationDir"
-				}
-			}
-		}
 	}
 	
 	/**
@@ -131,13 +142,6 @@ public class UpdateSitesConfigurationExtension {
 	 */
 	def from(String url) {
 		pluginInstance.add url
-	}
-	
-	/**
-	 * Makes the plugin perform the actual download.
-	 */
-	def download() {
-		pluginInstance.downloadSites()
 	}
 }
 	

--- a/buildSrc/src/main/groovy/DownloadUpdateSites.groovy
+++ b/buildSrc/src/main/groovy/DownloadUpdateSites.groovy
@@ -1,0 +1,143 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.apache.ivy.util.url.ApacheURLLister
+import de.undercouch.gradle.tasks.download.DownloadTaskPlugin
+import static groovyx.gpars.GParsPool.withPool
+
+/**
+ * Tasks downloading Eclipse Update Sites and making them available to wuff.
+ *
+ *	@author Joshua Gleitze
+ */
+public class DownloadUpdateSites implements Plugin<Project> {
+	/**
+	 * Stores the sites to download, mapped to the folders to put them to.
+	 */
+	def List<UpdateSite> sites = new ArrayList<>()
+	
+	/**
+	 * The configured project
+	 */
+	def Project project
+	
+	/**
+	 * Applies UpdateSitesConfigurationExtension to the project
+	 */
+	void apply(Project project) {
+		project.extensions.create "updatesites", UpdateSitesConfigurationExtension, this
+		this.project = project
+	}
+	
+	/**
+	 * Starts the download
+	 */
+    def downloadSites() {
+		project.apply plugin: DownloadTaskPlugin
+		
+		withPool(8) {
+			this.sites.eachParallel { updateSite ->
+				
+				if (!updateSite.checksumFile.exists() || !updateSite.destinationFolder.isDirectory()) {
+					download updateSite.url, updateSite.destinationFolder
+					
+					// unpuzzle’s dummy checksum
+					updateSite.checksumFile.text = 'deadbea1'
+				}
+			}
+		}
+    }
+    
+    /**
+     * Adds {@code url} to the sites to be downloaded. 
+     */
+    private void add(String url) {
+    	// create a folder name out of the URL
+		def dirName = url.replaceAll("[^a-zA-Z0-9.-]", "_")
+		def wuffDir = project.wuff.wuffDir ?: System.getProperty('user.home') + '/.wuff'
+		
+		// imitate unpuzzle’s checksum mechanism
+		def checksumFile = project.file("$wuffDir/downloaded-checksums/${dirName}.md5")
+		checksumFile.parentFile.mkdirs()
+		def destinationDir = project.file("$wuffDir/unpacked/$dirName")
+		
+		// queue the site to be downloaded
+		this.sites.add new UpdateSite(url: new URL(url), destinationFolder: destinationDir, checksumFile: checksumFile)
+		
+		// tell wuff about the downloaded folder
+		project.wuff {
+			eclipseVersion(selectedEclipseVersion) {
+				sources {
+					source "file://$destinationDir"
+				}
+			}
+		}
+	}
+	
+	/**
+	 * Update Site data object
+	 */
+	private class UpdateSite {
+		/**
+		 * The site’s URL.
+		 */
+		private URL url
+		/**
+		 * The folder to download the site to.
+		 */
+		private File destinationFolder
+		/**
+		 * The file to write a dummy checksum to to mark the site as downloaded.
+		 */
+		private File checksumFile
+	}
+
+	/**
+	 * Performs the actual, recursive download.
+	 *
+	 * @param url The url to be downloaded
+	 * @param destination The folder to put the downloaded files in.
+	 */
+	private void download(URL url, File destination) {
+		def lister = new ApacheURLLister()
+		destination.mkdirs()
+		project.download {
+			src lister.listFiles(url)
+			dest destination
+		}
+		for (folder in lister.listDirectories(url)) {
+			def destPart = url.toURI().relativize(folder.toURI()).toString()
+			download folder, project.file("$destination/$destPart") 
+		}
+	}
+}
+
+/**
+ * The configuration object passed to projects.
+ */
+public class UpdateSitesConfigurationExtension {
+
+	/**
+	 * Reference to the plugin instance.
+	 */
+	private DownloadUpdateSites pluginInstance
+	
+
+	public UpdateSitesConfigurationExtension(DownloadUpdateSites pluginInstance) {
+		this.pluginInstance = pluginInstance
+	}
+	
+	/**
+	 * Adds an update site to be downloaded and added to wuff.
+	 */
+	def from(String url) {
+		pluginInstance.add url
+	}
+	
+	/**
+	 * Makes the plugin perform the actual download.
+	 */
+	def download() {
+		pluginInstance.downloadSites()
+	}
+}
+	

--- a/buildSrc/src/main/groovy/dependencies.gradle
+++ b/buildSrc/src/main/groovy/dependencies.gradle
@@ -5,6 +5,6 @@ repositories {
 
 dependencies {
 	compile group: 'org.codehaus.gpars', name: 'gpars', version: '1.2+'
-    compile group: 'org.apache.ivy', name: 'ivy', version: '+'
-    compile group: 'de.undercouch', name: 'gradle-download-task', version: '+'
+	compile group: 'org.apache.ivy', name: 'ivy', version: '+'
+	compile group: 'de.undercouch', name: 'gradle-download-task', version: '+'
 }

--- a/buildSrc/src/main/groovy/dependencies.gradle
+++ b/buildSrc/src/main/groovy/dependencies.gradle
@@ -1,0 +1,10 @@
+repositories {
+	mavenCentral()
+	jcenter()
+}
+
+dependencies {
+	compile group: 'org.codehaus.gpars', name: 'gpars', version: '1.2+'
+    compile group: 'org.apache.ivy', name: 'ivy', version: '+'
+    compile group: 'de.undercouch', name: 'gradle-download-task', version: '+'
+}

--- a/buildSrc/src/tasks/gradle/20 eclipse.gradle
+++ b/buildSrc/src/tasks/gradle/20 eclipse.gradle
@@ -6,20 +6,15 @@
 
 buildscript {
 	repositories {
-		mavenLocal()
 		jcenter()
 	}
   
 	dependencies {
 		classpath group: 'org.akhikhl.wuff', name: 'wuff-plugin', version: '+'
-        classpath group: 'de.undercouch', name: 'gradle-download-task', version: '+'
-        classpath group: 'org.apache.ivy', name: 'ivy', version: '+' 
 	}
 }
-
 import org.akhikhl.wuff.EclipseBundlePlugin
-import de.undercouch.gradle.tasks.download.DownloadTaskPlugin
-import org.apache.ivy.util.url.ApacheURLLister
+
 
 configure(eclipseSubprojects) {
 	repositories {
@@ -27,61 +22,22 @@ configure(eclipseSubprojects) {
 		jcenter()
 	}
 	
+	apply plugin: DownloadUpdateSites	
 	apply plugin: EclipseBundlePlugin
-	apply plugin: DownloadTaskPlugin
-	
-	def lister = new ApacheURLLister()
-	
-	/**
-	 * Recursivly downloads an update site.
-	 */
-	def downloadUpdatesite
-	downloadUpdatesite = { URL url, destinationDir ->
-		file(destinationDir).mkdirs()
-		project.download {
-			src lister.listFiles(url)
-			dest destinationDir
-		}
-		for (folder in lister.listDirectories(url)) {
-			def destPart = url.toURI().relativize(folder.toURI()).toString()
-			downloadUpdatesite folder, "$destinationDir/$destPart" 
-		}
-	}
-	
-	/**
-	 * Downloads an update site and provides a path to it to be used by wuff.
-	 * 
-	 * @param url The update site’s url.
-	 */
-	def updatesite = { url ->
-		// create a folder name out of the URL
-		def dirName = url.replaceAll("[^a-zA-Z0-9.-]", "_")
-		def wuffDir = project.wuff.wuffDir ?: System.getProperty('user.home') + '/.wuff'
+
+	project.updatesites {
+		/*
+		 * Define the needed update sites for ALL projects here!
+		 */
+		from 'https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/nightly/aggregate/' // PCM
+		from 'http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/modeling/gmp/updates/releases/' // required by Context Menu Prototype
+		from 'http://ftp.fau.de/eclipse/modeling/emf/updates/releases/' // EMF
 		
-		// imitate unpuzzle’s checksum mechanism
-		def checksumFile = file("$wuffDir/downloaded-checksums/${dirName}.md5")
-		checksumFile.parentFile.mkdirs()
-		def destinationDir = "$wuffDir/unpacked/$dirName"
-		
-		if (!checksumFile.exists() || !file(destinationDir).isDirectory()) {
-			downloadUpdatesite new URL(url), destinationDir
-			// unpuzzle’s dummy checksum
-			checksumFile.text = 'deadbea1'
-		}
-		return "file://$destinationDir"
+		download()
 	}
+
 	
 	project.wuff {
 		selectedEclipseVersion = '4.5'
-		
-		eclipseVersion('4.5') {
-			sources {
-				/*
-				 * Define the needed update sites for ALL projects here!
-				 */
-				source updatesite('https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/nightly/aggregate/') // PCM
-				source updatesite('http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/modeling/gmp/updates/releases/') // required by Context Menu Prototype
-			}
-		}
 	} 
 }

--- a/buildSrc/src/tasks/gradle/20 eclipse.gradle
+++ b/buildSrc/src/tasks/gradle/20 eclipse.gradle
@@ -17,11 +17,6 @@ import org.akhikhl.wuff.EclipseBundlePlugin
 
 
 configure(eclipseSubprojects) {
-	repositories {
-		mavenLocal()
-		jcenter()
-	}
-	
 	apply plugin: DownloadUpdateSites	
 	apply plugin: EclipseBundlePlugin
 
@@ -30,12 +25,9 @@ configure(eclipseSubprojects) {
 		 * Define the needed update sites for ALL projects here!
 		 */
 		from 'https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/nightly/aggregate/' // PCM
-		from 'http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/modeling/gmp/updates/releases/' // required by Context Menu Prototype
+		from 'http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/modeling/gmp/updates/releases/' // GMF, required by Context Menu Prototype
 		from 'http://ftp.fau.de/eclipse/modeling/emf/updates/releases/' // EMF
-		
-		download()
 	}
-
 	
 	project.wuff {
 		selectedEclipseVersion = '4.5'


### PR DESCRIPTION
#613 requires another update site, which would make Travis builds longer than 20 minutes.

This PR restructures my Update Site hack. It also introduces concurrency, which is very effective: The normally 20 minutes build now only takes 12 minutes. Downloading the Update sites takes ~420 seconds instead of ~890 seconds.

The PR also already adds the EMF site that will be needed for #613

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/646)
<!-- Reviewable:end -->
