### PR TITLE
Improved Error Message of NullHandlingMactchers

### DIFF
--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/NullHandlingMatchers.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/NullHandlingMatchers.java
@@ -138,6 +138,11 @@ public final class NullHandlingMatchers {
 		extends TypeSafeDiagnosingMatcher<Consumer<Collection<CONSUMED_TYPE>>> {
 
 		/**
+		 * Description of what was expected.
+		 */
+		private String expectedDescription;
+
+		/**
 		 * A list of values that are accepted by the examined lambda.
 		 */
 		private final List<CONSUMED_TYPE> testValues;
@@ -156,8 +161,7 @@ public final class NullHandlingMatchers {
 
 		@Override
 		public void describeTo(final Description description) {
-			description.appendText("a method throwing a NullPointerException"
-				+ " if an element in its argument or the argument itself is null");
+			description.appendText(this.expectedDescription);
 		}
 
 		@Override
@@ -166,6 +170,7 @@ public final class NullHandlingMatchers {
 			ThrowingMethod nullApplied;
 
 			// feed null
+			this.expectedDescription = "a method throwing a NullPointerException if a passed collection is null";
 			nullApplied = () -> consumer.accept(null);
 			if (!THROWS_NPE.matches(nullApplied)) {
 				THROWS_NPE.describeMismatch(nullApplied, mismatchDescription);
@@ -177,6 +182,8 @@ public final class NullHandlingMatchers {
 			final List<List<CONSUMED_TYPE>> inputsWithNull = Arrays.asList(withNull(this.testValues, 0),
 				withNull(this.testValues, this.testValues.size() / 2), withNull(this.testValues));
 
+			this.expectedDescription =
+				"a method throwing an IllegalArgumentException if a passed collection contains null";
 			// feed the lists containing null
 			for (final List<CONSUMED_TYPE> testInputsWithNull : inputsWithNull) {
 				nullApplied = () -> consumer.accept(testInputsWithNull);


### PR DESCRIPTION
In the moment, it might tell you

> Expected a method throwing a NullPointerException […]
but: a NullPointerException was thrown […]

which is really irritating. So I fixed those messages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/651)
<!-- Reviewable:end -->
