### PR TITLE
Fix Dependency Import

### DIFF
--- a/Core/dependencies.gradle
+++ b/Core/dependencies.gradle
@@ -1,6 +1,8 @@
 dependencies {
 	// Production dependencies
 	production group: 'org.apache.commons', name: 'commons-lang3', version: '3.4+'
+	production group: 'org.apache.commons', name: 'commons-collections4', version: '4.1+'
+	
 	
 	// Test dependencies
 	tests group: 'junit', name: 'junit', version: '4.+'

--- a/Core/src/main/resources/META-INF/MANIFEST.MF
+++ b/Core/src/main/resources/META-INF/MANIFEST.MF
@@ -4,4 +4,3 @@ Bundle-Name: Beagle Core
 Bundle-SymbolicName: de.uka.ipd.sdq.beagle.core
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.apache.commons.lang3

--- a/buildSrc/src/tasks/gradle/30 eclipse project setup.gradle
+++ b/buildSrc/src/tasks/gradle/30 eclipse project setup.gradle
@@ -15,7 +15,6 @@ configure(javaSubprojects) {
 	configurations.compile.extendsFrom configurations.production
 	configurations.testCompile.extendsFrom configurations.tests
 
-	println project.configurations
 	// we only want to export the test dependencies to Eclipse.
 	eclipse {
 		classpath {

--- a/buildSrc/src/tasks/gradle/30 eclipse project setup.gradle
+++ b/buildSrc/src/tasks/gradle/30 eclipse project setup.gradle
@@ -15,11 +15,14 @@ configure(javaSubprojects) {
 	configurations.compile.extendsFrom configurations.production
 	configurations.testCompile.extendsFrom configurations.tests
 
+	println project.configurations
 	// we only want to export the test dependencies to Eclipse.
 	eclipse {
 		classpath {
-			minusConfigurations += [project.configurations.compile]
-			plusConfigurations += [project.configurations.tests, project.configurations.production]
+			plusConfigurations = [project.configurations.tests, project.configurations.production]
+			
+			downloadSources true
+			downloadJavadoc true
 		}
 	}
 }


### PR DESCRIPTION
This is the fix for the import of production dependencies into Eclipse that is already merged into some branches.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/654)
<!-- Reviewable:end -->
