### PR TITLE
New Hamcrest Version -> Import fix

### DIFF
--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/CodeSectionTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/CodeSectionTest.java
@@ -5,8 +5,8 @@ import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsE
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.CoreMatchers.theInstance;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertThat;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
@@ -158,16 +158,16 @@ public class CodeSectionTest {
 		final int startCodeLine = 4;
 		final int endCodeLine = 15;
 		CodeSection codeSection = new CodeSection(file, startCodeLine, file, endCodeLine);
-		assertThat(codeSection.getEndFile(), is(theInstance(file)));
+		assertThat(codeSection.getEndFile(), is(sameInstance(file)));
 
 		final File secFile = files[1];
 		final int startIndex = 60;
 		final int endIndex = 68;
 		codeSection = new CodeSection(secFile, startIndex, secFile, endIndex);
-		assertThat(codeSection.getEndFile(), is(theInstance(secFile)));
+		assertThat(codeSection.getEndFile(), is(sameInstance(secFile)));
 
 		codeSection = new CodeSection(file, startCodeLine, secFile, endIndex);
-		assertThat(codeSection.getEndFile(), is(theInstance(secFile)));
+		assertThat(codeSection.getEndFile(), is(sameInstance(secFile)));
 	}
 
 	/**
@@ -197,13 +197,13 @@ public class CodeSectionTest {
 		final int startCodeLine = 4;
 		final int endCodeLine = 15;
 		CodeSection codeSection = new CodeSection(file, startCodeLine, file, endCodeLine);
-		assertThat(codeSection.getStartFile(), is(theInstance(file)));
+		assertThat(codeSection.getStartFile(), is(sameInstance(file)));
 
 		final File secFile = files[1];
 		final int startIndex = 60;
 		final int endIndex = 68;
 		codeSection = new CodeSection(secFile, startIndex, secFile, endIndex);
-		assertThat(codeSection.getStartFile(), is(theInstance(secFile)));
+		assertThat(codeSection.getStartFile(), is(sameInstance(secFile)));
 	}
 
 	/**

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ExternalCallParameterTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ExternalCallParameterTest.java
@@ -5,7 +5,7 @@ import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsE
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertThat;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ResourceDemandTypeTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ResourceDemandTypeTest.java
@@ -5,7 +5,7 @@ import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsE
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertThat;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffBranchTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffBranchTest.java
@@ -5,9 +5,9 @@ import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsE
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.fail;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffLoopTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffLoopTest.java
@@ -5,9 +5,9 @@ import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsE
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.CoreMatchers.theInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
 import de.uka.ipd.sdq.beagle.core.testutil.factories.CodeSectionFactory;
@@ -64,7 +64,7 @@ public class SeffLoopTest {
 		SeffLoop loop;
 		for (final CodeSection codeSection : codeSections) {
 			loop = new SeffLoop(codeSection);
-			assertThat(loop.getLoopBody(), is(theInstance(codeSection)));
+			assertThat(loop.getLoopBody(), is(sameInstance(codeSection)));
 		}
 	}
 


### PR DESCRIPTION
adapted imports and usage to new hamcrest.core for `theInstance` and `startsWith` as both were moved to another package in the new hamcrest version

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/655)
<!-- Reviewable:end -->
