### PR TITLE
Better Debug Output

### DIFF
--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/CodeSection.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/CodeSection.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.io.File;
 import java.io.Serializable;
@@ -114,8 +113,10 @@ public class CodeSection implements Serializable {
 		}
 		final CodeSection other = (CodeSection) object;
 		return new EqualsBuilder().append(this.startFile, other.startFile)
-			.append(this.startStatementNumber, other.startStatementNumber).append(this.endFile, other.endFile)
-			.append(this.endStatementNumber, other.endStatementNumber).isEquals();
+			.append(this.startStatementNumber, other.startStatementNumber)
+			.append(this.endFile, other.endFile)
+			.append(this.endStatementNumber, other.endStatementNumber)
+			.isEquals();
 	}
 
 	/**
@@ -165,15 +166,20 @@ public class CodeSection implements Serializable {
 	public int hashCode() {
 		// you pick a hard-coded, randomly chosen, non-zero, odd number
 		// ideally different for each class
-		return new HashCodeBuilder(23, 45).append(this.startFile).append(this.startStatementNumber).append(this.endFile)
-			.append(this.endStatementNumber).toHashCode();
+		return new HashCodeBuilder(23, 45).append(this.startFile)
+			.append(this.startStatementNumber)
+			.append(this.endFile)
+			.append(this.endStatementNumber)
+			.toHashCode();
 	}
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("startFile", this.startFile)
-			.append("startStatementNumber", this.startStatementNumber).append("endFile", this.endFile)
-			.append("endStatementNumber", this.endStatementNumber).toString();
+		final String startFileName = this.startFile.getName().replace(".java", "");
+		final String endFileName =
+			this.startFile.equals(this.endFile) ? "" : this.endFile.getName().replace(".java", "") + ":";
+		return String.format("%s:%d–%s%d", startFileName, this.startStatementNumber, endFileName,
+			this.endStatementNumber);
 	}
 
 	/**

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/ExternalCallParameter.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/ExternalCallParameter.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A parameter of an external call.
@@ -84,6 +83,6 @@ public class ExternalCallParameter implements MeasurableSeffElement {
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("call", this.call).append("index", this.index).toString();
+		return String.format("ExCall@%4.4s<%d,%s>", Integer.toHexString(this.hashCode()), this.index, this.call);
 	}
 }

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/ResourceDemandType.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/ResourceDemandType.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Represents a type of a measured resource, like CPU usage or HDD usage.
@@ -133,6 +132,6 @@ public class ResourceDemandType {
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("name", this.name).append("isNs", this.isNs).toString();
+		return this.name + (this.isNs ? "_NS" : "");
 	}
 }

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/ResourceDemandingInternalAction.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/ResourceDemandingInternalAction.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Models an internal action demanding resources of a specific type when being executed.
@@ -66,7 +65,8 @@ public class ResourceDemandingInternalAction implements MeasurableSeffElement {
 			return false;
 		}
 		final ResourceDemandingInternalAction other = (ResourceDemandingInternalAction) object;
-		return new EqualsBuilder().append(this.resourceType, other.resourceType).append(this.action, other.action)
+		return new EqualsBuilder().append(this.resourceType, other.resourceType)
+			.append(this.action, other.action)
 			.isEquals();
 	}
 
@@ -101,7 +101,6 @@ public class ResourceDemandingInternalAction implements MeasurableSeffElement {
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("resourceType", this.resourceType).append("action", this.action)
-			.toString();
+		return String.format("RDIA@%4.4s<%s,%s>", Integer.toHexString(this.hashCode()), this.resourceType, this.action);
 	}
 }

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/SeffBranch.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/SeffBranch.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -102,6 +101,6 @@ public class SeffBranch implements MeasurableSeffElement {
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("branches", this.branches).toString();
+		return String.format("SeffBranch@%4.4s<%s>", Integer.toHexString(this.hashCode()), this.branches);
 	}
 }

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/SeffLoop.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/SeffLoop.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Models loops (like Java’s for , while and do - while statement) which affect the calls
@@ -70,6 +69,6 @@ public class SeffLoop implements MeasurableSeffElement {
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("loopBody", this.loopBody).toString();
+		return String.format("SeffLoop@%4.4s<%s>", Integer.toHexString(this.hashCode()), this.loopBody);
 	}
 }

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/BranchDecisionMeasurementResult.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/BranchDecisionMeasurementResult.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core.measurement;
 import de.uka.ipd.sdq.beagle.core.SeffBranch;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A result of measuring which branch is taken in a branching source code construct. This
@@ -19,7 +18,7 @@ public class BranchDecisionMeasurementResult extends ParameterisationDependentMe
 	 * The index of the branch in the associated {@link SeffBranch}'s branch list that was
 	 * executed.
 	 */
-	private int branchIndex;
+	private final int branchIndex;
 
 	/**
 	 * Creates a result for a branch measurement for which no parameterisation was
@@ -58,7 +57,8 @@ public class BranchDecisionMeasurementResult extends ParameterisationDependentMe
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).appendSuper(super.toString()).append("branch index", this.branchIndex)
-			.toString();
+		return String.format("BranchResult@%4.4s<%d,%s>", Integer.toHexString(this.hashCode()), this.branchIndex,
+			this.getParameterisation());
+
 	}
 }

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/BranchDecisionMeasurementResult.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/BranchDecisionMeasurementResult.java
@@ -41,7 +41,7 @@ public class BranchDecisionMeasurementResult extends ParameterisationDependentMe
 	 */
 	public BranchDecisionMeasurementResult(final Parameterisation parameterisation, final int branchIndex) {
 		super(parameterisation);
-		Validate.isTrue(branchIndex >= 0, "The measured branch index was negative: %d", this.branchIndex);
+		Validate.isTrue(branchIndex >= 0, "The measured branch index was negative: %d", branchIndex);
 		this.branchIndex = branchIndex;
 	}
 

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/LoopRepetitionCountMeasurementResult.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/LoopRepetitionCountMeasurementResult.java
@@ -1,7 +1,6 @@
 package de.uka.ipd.sdq.beagle.core.measurement;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A result of counting repetitions of a loop. It expresses that a loop construct’s body
@@ -16,7 +15,7 @@ public class LoopRepetitionCountMeasurementResult extends ParameterisationDepend
 	/**
 	 * How many times the loop's body was executed.
 	 */
-	private int count;
+	private final int count;
 
 	/**
 	 * Creates a result for a loop measurement for which no parameterisation was recorded.
@@ -51,6 +50,8 @@ public class LoopRepetitionCountMeasurementResult extends ParameterisationDepend
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).appendSuper(super.toString()).append("count", this.count).toString();
+		return String.format("LoopResult@%4.4s<%f,%s>", Integer.toHexString(this.hashCode()), this.count,
+			this.getParameterisation());
+
 	}
 }

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/LoopRepetitionCountMeasurementResult.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/LoopRepetitionCountMeasurementResult.java
@@ -50,7 +50,7 @@ public class LoopRepetitionCountMeasurementResult extends ParameterisationDepend
 
 	@Override
 	public String toString() {
-		return String.format("LoopResult@%4.4s<%f,%s>", Integer.toHexString(this.hashCode()), this.count,
+		return String.format("LoopResult@%4.4s<%d,%s>", Integer.toHexString(this.hashCode()), this.count,
 			this.getParameterisation());
 
 	}

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/ResourceDemandMeasurementResult.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/measurement/ResourceDemandMeasurementResult.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.beagle.core.measurement;
 import de.uka.ipd.sdq.beagle.core.ResourceDemandingInternalAction;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A result of measuring resource demands of a code section. The result expresses that a
@@ -23,7 +22,7 @@ public class ResourceDemandMeasurementResult extends ParameterisationDependentMe
 	 * The value measured. The unit is specified by the
 	 * {@link ResourceDemandingInternalAction}'s type it belongs to.
 	 */
-	private double value;
+	private final double value;
 
 	/**
 	 * Creates a result for a resource demand measurement for which no parameterisation
@@ -65,6 +64,7 @@ public class ResourceDemandMeasurementResult extends ParameterisationDependentMe
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).appendSuper(super.toString()).append("value", this.value).toString();
+		return String.format("RDResult@%4.4s<%.2f,%s>", Integer.toHexString(this.hashCode()), this.value,
+			this.getParameterisation());
 	}
 }

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/CodeSectionTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/CodeSectionTest.java
@@ -2,11 +2,11 @@ package de.uka.ipd.sdq.beagle.core;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.EqualsMatcher.hasDefaultEqualsProperties;
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.IsSame.sameInstance;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertThat;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
@@ -215,7 +215,7 @@ public class CodeSectionTest {
 		final int startCodeLine = 4;
 		final int endCodeLine = 15;
 		final CodeSection codeSection = new CodeSection(file, startCodeLine, file, endCodeLine);
-		assertThat(codeSection.toString(), not(startsWith("CodeSection@")));
+		assertThat(codeSection, hasOverriddenToString());
 	}
 
 }

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ExternalCallParameterTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ExternalCallParameterTest.java
@@ -2,10 +2,10 @@ package de.uka.ipd.sdq.beagle.core;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.EqualsMatcher.hasDefaultEqualsProperties;
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertThat;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
@@ -108,7 +108,7 @@ public class ExternalCallParameterTest {
 		final CodeSection[] codeSections = CODE_SECTION_FACTORY.getAll();
 		for (final CodeSection codeSection : codeSections) {
 			final ExternalCallParameter externalCallP = new ExternalCallParameter(codeSection, 1);
-			assertThat(externalCallP.toString(), not(startsWith("ExternalCallParameter@")));
+			assertThat(externalCallP, hasOverriddenToString());
 		}
 	}
 

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ResourceDemandTypeTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ResourceDemandTypeTest.java
@@ -2,11 +2,11 @@ package de.uka.ipd.sdq.beagle.core;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.EqualsMatcher.hasDefaultEqualsProperties;
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.junit.Assert.assertThat;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
 
@@ -87,7 +87,7 @@ public class ResourceDemandTypeTest {
 	@Test
 	public void toStringT() {
 		final ResourceDemandType type = new ResourceDemandType("test", true);
-		assertThat(type.toString(), not(startsWith("ResourceDemandType@")));
+		assertThat(type, hasOverriddenToString());
 	}
 
 }

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ResourceDemandingInternalActionTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/ResourceDemandingInternalActionTest.java
@@ -2,11 +2,11 @@ package de.uka.ipd.sdq.beagle.core;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.EqualsMatcher.hasDefaultEqualsProperties;
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.IsSame.sameInstance;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertThat;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
@@ -140,7 +140,7 @@ public class ResourceDemandingInternalActionTest {
 		for (final CodeSection codeSection : codeSections) {
 			final ResourceDemandingInternalAction rdia =
 				new ResourceDemandingInternalAction(ResourceDemandType.RESOURCE_TYPE_CPU, codeSection);
-			assertThat(rdia.toString(), not(startsWith("ResourceDemandingInternalAction@")));
+			assertThat(rdia, hasOverriddenToString());
 		}
 	}
 

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffBranchTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffBranchTest.java
@@ -2,12 +2,12 @@ package de.uka.ipd.sdq.beagle.core;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.EqualsMatcher.hasDefaultEqualsProperties;
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.fail;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
@@ -149,7 +149,7 @@ public class SeffBranchTest {
 		final Set<CodeSection> codeSections = CODE_SECTION_FACTORY.getAllAsSet();
 		final SeffBranch branch = new SeffBranch(codeSections);
 
-		assertThat(branch.toString(), not(startsWith("SeffBranch@")));
+		assertThat(branch, hasOverriddenToString());
 	}
 
 }

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffLoopTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/SeffLoopTest.java
@@ -2,12 +2,12 @@ package de.uka.ipd.sdq.beagle.core;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.EqualsMatcher.hasDefaultEqualsProperties;
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsSame.sameInstance;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 
 import de.uka.ipd.sdq.beagle.core.testutil.ThrowingMethod;
 import de.uka.ipd.sdq.beagle.core.testutil.factories.CodeSectionFactory;
@@ -77,7 +77,7 @@ public class SeffLoopTest {
 		SeffLoop loop;
 		for (final CodeSection codeSection : codeSections) {
 			loop = new SeffLoop(codeSection);
-			assertThat(loop.toString(), not(startsWith("SeffLoop@")));
+			assertThat(loop, hasOverriddenToString());
 		}
 	}
 

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/BranchDecisionMeasurementResultTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/BranchDecisionMeasurementResultTest.java
@@ -1,10 +1,9 @@
 package de.uka.ipd.sdq.beagle.core.measurement;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -100,8 +99,8 @@ public class BranchDecisionMeasurementResultTest {
 		final BranchDecisionMeasurementResult measurementResultP =
 			new BranchDecisionMeasurementResult(parameterisation, value) {
 			};
-		assertThat(measurementResult.toString(), not(startsWith("BranchDecisionMeasurementResult@")));
-		assertThat(measurementResultP.toString(), not(startsWith("BranchDecisionMeasurementResult@")));
+		assertThat(measurementResult, hasOverriddenToString());
+		assertThat(measurementResultP, hasOverriddenToString());
 	}
 
 }

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/LoopRepetitionCountMeasurementResultTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/LoopRepetitionCountMeasurementResultTest.java
@@ -1,10 +1,9 @@
 package de.uka.ipd.sdq.beagle.core.measurement;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -101,8 +100,8 @@ public class LoopRepetitionCountMeasurementResultTest {
 		final LoopRepetitionCountMeasurementResult measurementResultP =
 			new LoopRepetitionCountMeasurementResult(parameterisation, value) {
 			};
-		assertThat(measurementResult.toString(), not(startsWith("LoopRepetitionCountMeasurementResult@")));
-		assertThat(measurementResultP.toString(), not(startsWith("LoopRepetitionCountMeasurementResult@")));
+		assertThat(measurementResult, hasOverriddenToString());
+		assertThat(measurementResultP, hasOverriddenToString());
 	}
 
 }

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/ParameterisationDependentMeasurementResultTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/ParameterisationDependentMeasurementResultTest.java
@@ -1,10 +1,9 @@
 package de.uka.ipd.sdq.beagle.core.measurement;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -80,8 +79,8 @@ public class ParameterisationDependentMeasurementResultTest {
 		final ParameterisationDependentMeasurementResult measurementResultP =
 			new ParameterisationDependentMeasurementResult(parameterisation) {
 			};
-		assertThat(measurementResult.toString(), not(startsWith("ParameterisationDependentMeasurementResult@")));
-		assertThat(measurementResultP.toString(), not(startsWith("ParameterisationDependentMeasurementResult@")));
+		assertThat(measurementResult, hasOverriddenToString());
+		assertThat(measurementResultP, hasOverriddenToString());
 	}
 
 }

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/ResourceDemandMeasurementResultTest.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/measurement/ResourceDemandMeasurementResultTest.java
@@ -1,10 +1,9 @@
 package de.uka.ipd.sdq.beagle.core.measurement;
 
 import static de.uka.ipd.sdq.beagle.core.testutil.ExceptionThrownMatcher.throwsException;
+import static de.uka.ipd.sdq.beagle.core.testutil.ToStringMatcher.hasOverriddenToString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -99,8 +98,8 @@ public class ResourceDemandMeasurementResultTest {
 		final ResourceDemandMeasurementResult measurementResultP =
 			new ResourceDemandMeasurementResult(parameterisation, value) {
 			};
-		assertThat(measurementResult.toString(), not(startsWith("ResourceDemandMeasurementResult@")));
-		assertThat(measurementResultP.toString(), not(startsWith("ResourceDemandMeasurementResult@")));
+		assertThat(measurementResult, hasOverriddenToString());
+		assertThat(measurementResultP, hasOverriddenToString());
 	}
 
 }


### PR DESCRIPTION
Our `toString` conversions were imho way to long to help debugging. I though though of shorter ways for our main business objects.

 * Still include the hash code (helps identifying), but only 4 hex digits
 * Omit class names were they will always be clear from the context
 * Omit value descriptions because they can be guessed from the context.

I debugged a little with those and found them quite helpful. Especially for composed data structures like Maps, you get surprisingly helpful debug output. But only if the values are short enough.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/736)
<!-- Reviewable:end -->
