### PR TITLE
added "false" to Equals Matcher

### DIFF
--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/EqualsMatcher.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/EqualsMatcher.java
@@ -45,6 +45,7 @@ public final class EqualsMatcher extends DiagnosingMatcher<Object> {
 		}
 		if (!examined.equals(examined)) {
 			mismatchDescription.appendText("the object was not equal to itself");
+			return false;
 		}
 		if (examined.equals(new Object())) {
 			mismatchDescription.appendText("the object is equal to a new object");


### PR DESCRIPTION
Seems like I forgot to fail in the EqualsMatcher if the result of object.equals(object) is false. I am sorry. Luckily I do not think adding this changes makes something fail, so all of us did it right.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/741)
<!-- Reviewable:end -->
