### PR TITLE
Moved Facade-Specific Classes out of Core

### DIFF
--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/BeagleController.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/BeagleController.java
@@ -2,7 +2,6 @@ package de.uka.ipd.sdq.beagle.core.facade;
 
 import de.uka.ipd.sdq.beagle.core.AnalysisController;
 import de.uka.ipd.sdq.beagle.core.Blackboard;
-import de.uka.ipd.sdq.beagle.core.BlackboardCreator;
 import de.uka.ipd.sdq.beagle.core.LaunchConfiguration;
 import de.uka.ipd.sdq.beagle.core.ProjectInformation;
 import de.uka.ipd.sdq.beagle.core.analysis.MeasurementResultAnalyserContributionsHandler;

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/BlackboardCreator.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/BlackboardCreator.java
@@ -1,5 +1,11 @@
-package de.uka.ipd.sdq.beagle.core;
+package de.uka.ipd.sdq.beagle.core.facade;
 
+import de.uka.ipd.sdq.beagle.core.Blackboard;
+import de.uka.ipd.sdq.beagle.core.ExternalCallParameter;
+import de.uka.ipd.sdq.beagle.core.ProjectInformation;
+import de.uka.ipd.sdq.beagle.core.ResourceDemandingInternalAction;
+import de.uka.ipd.sdq.beagle.core.SeffBranch;
+import de.uka.ipd.sdq.beagle.core.SeffLoop;
 import de.uka.ipd.sdq.beagle.core.judge.EvaluableExpressionFitnessFunction;
 import de.uka.ipd.sdq.beagle.core.pcmconnection.PcmBeagleMappings;
 import de.uka.ipd.sdq.beagle.core.pcmconnection.PcmRepositoryBlackboardFactoryAdder;

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/EclipseLaunchConfiguration.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/EclipseLaunchConfiguration.java
@@ -1,5 +1,6 @@
-package de.uka.ipd.sdq.beagle.core;
+package de.uka.ipd.sdq.beagle.core.facade;
 
+import de.uka.ipd.sdq.beagle.core.LaunchConfiguration;
 import de.uka.ipd.sdq.beagle.core.failurehandling.FailureHandler;
 import de.uka.ipd.sdq.beagle.core.failurehandling.FailureReport;
 

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/LauchConfigurationProvider.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/facade/LauchConfigurationProvider.java
@@ -1,6 +1,5 @@
 package de.uka.ipd.sdq.beagle.core.facade;
 
-import de.uka.ipd.sdq.beagle.core.EclipseLaunchConfiguration;
 import de.uka.ipd.sdq.beagle.core.LaunchConfiguration;
 import de.uka.ipd.sdq.beagle.core.failurehandling.FailureHandler;
 import de.uka.ipd.sdq.beagle.core.failurehandling.FailureReport;

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositoryBlackboardFactoryAdder.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositoryBlackboardFactoryAdder.java
@@ -1,8 +1,8 @@
 package de.uka.ipd.sdq.beagle.core.pcmconnection;
 
 import de.uka.ipd.sdq.beagle.core.Blackboard;
-import de.uka.ipd.sdq.beagle.core.BlackboardCreator;
 import de.uka.ipd.sdq.beagle.core.BlackboardStorer;
+import de.uka.ipd.sdq.beagle.core.facade.BlackboardCreator;
 import de.uka.ipd.sdq.beagle.core.facade.SourceCodeFileProvider;
 
 import org.eclipse.emf.ecore.EObject;

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositoryExtractor.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositoryExtractor.java
@@ -1,11 +1,11 @@
 package de.uka.ipd.sdq.beagle.core.pcmconnection;
 
 import de.uka.ipd.sdq.beagle.core.Blackboard;
-import de.uka.ipd.sdq.beagle.core.BlackboardCreator;
 import de.uka.ipd.sdq.beagle.core.ExternalCallParameter;
 import de.uka.ipd.sdq.beagle.core.ResourceDemandingInternalAction;
 import de.uka.ipd.sdq.beagle.core.SeffBranch;
 import de.uka.ipd.sdq.beagle.core.SeffLoop;
+import de.uka.ipd.sdq.beagle.core.facade.BlackboardCreator;
 import de.uka.ipd.sdq.beagle.core.facade.SourceCodeFileProvider;
 
 import de.uka.ipd.sdq.identifier.Identifier;

--- a/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/factories/LaunchConfigurationFactory.java
+++ b/Core/src/test/java/de/uka/ipd/sdq/beagle/core/testutil/factories/LaunchConfigurationFactory.java
@@ -2,8 +2,8 @@ package de.uka.ipd.sdq.beagle.core.testutil.factories;
 
 import static org.mockito.Mockito.mock;
 
-import de.uka.ipd.sdq.beagle.core.EclipseLaunchConfiguration;
 import de.uka.ipd.sdq.beagle.core.LaunchConfiguration;
+import de.uka.ipd.sdq.beagle.core.facade.EclipseLaunchConfiguration;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IJavaProject;


### PR DESCRIPTION
Fixes #742 

I think that only facade and pcmconnection classes were affected by this change proves my point.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/750)
<!-- Reviewable:end -->
