### PR TITLE
[Checkstyle] Improve Handling of Comment in Empty Catch Block

### DIFF
--- a/config/checkstyle/Checkstyle Prototype.xml
+++ b/config/checkstyle/Checkstyle Prototype.xml
@@ -266,7 +266,8 @@
     </module>
     <module name="EmptyCatchBlock">
       <property name="severity" value="warning"/>
-      <property name="commentFormat" value=".{10,} because .{10,}\."/>
+      <property name="commentFormat" value=".{10,}"/>
+      <message key="catch.block.empty" value="Empty catch block. Please provide a description why it’s being left empty!"/>
     </module>
     <module name="LeftCurly">
       <property name="severity" value="warning"/>

--- a/config/checkstyle/Checkstyle Test.xml
+++ b/config/checkstyle/Checkstyle Test.xml
@@ -269,7 +269,8 @@
     </module>
     <module name="EmptyCatchBlock">
       <property name="severity" value="warning"/>
-      <property name="commentFormat" value=".{10,} because .{10,}\."/>
+      <property name="commentFormat" value=".{10,}"/>
+      <message key="catch.block.empty" value="Empty catch block. Please provide a description why it’s being left empty!"/>
     </module>
     <module name="LeftCurly">
       <property name="severity" value="warning"/>

--- a/config/checkstyle/Checkstyle.xml
+++ b/config/checkstyle/Checkstyle.xml
@@ -266,7 +266,8 @@
     </module>
     <module name="EmptyCatchBlock">
       <property name="severity" value="warning"/>
-      <property name="commentFormat" value=".{10,} because .{10,}\."/>
+      <property name="commentFormat" value=".{10,}"/>
+      <message key="catch.block.empty" value="Empty catch block. Please provide a description why it’s being left empty!"/>
     </module>
     <module name="LeftCurly">
       <property name="severity" value="warning"/>


### PR DESCRIPTION
Empty catch blocks are not a bad thing if handling the exception is implicitly done by the outside code. However, the programmer should provide a comment to state this fact and to assure readers that he thought of catching the exception (and making clear how it will be handled).

This was already active in Checkstyle. However, the default rule requires the comment to contain “because”, which I think makes no sense. Furthermore, I improved the rule’s message to point to the fact that empty catch blocks are accepted if they contain an explanation.

On a side note: Please stop immediately to disable Checkstyle if it gets in your way! If you think a warning is not justified, there are to possibilities:
 a) You’re wrong
 b) Checkstyle’s wrong

In either way, we need to discuss the issue. Disabling Checkstyle effectively prevents it from doing its job, which is to keep our code clean.
The disable feature is only meant to be used to overcome technical shortcomings or very rare edge cases.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/763)
<!-- Reviewable:end -->
