### PR TITLE
Fix Weird Zip Error

### DIFF
--- a/buildSrc/src/tasks/gradle/30 deploy test projects.gradle
+++ b/buildSrc/src/tasks/gradle/30 deploy test projects.gradle
@@ -17,7 +17,6 @@ buildscript {
 apply plugin: 'de.undercouch.download'
 
 def tmp = file("$buildDir/tmp/test-resources")
-tmp.mkdirs()
 
 def cocomeDest = file("$projectDir/src/test/resources/CoCoME")
 def appsensorDest = file("$projectDir/src/test/resources/AppSensor")
@@ -38,6 +37,8 @@ task downloadCocome {
 	outputs.dir cocomeDest
 	
 	doLast {
+		tmp.mkdirs()
+		
 		download {
 			src ([
 				'http://www.cocome.org/downloads/implementation/cocome-impl.zip',
@@ -64,7 +65,9 @@ task downloadAppSensor {
 	outputs.dir appsensorDest
 	
 	doLast {
-		rootProject.download {
+		tmp.mkdirs()
+		
+		download {
 			src 'https://github.com/jtmelton/appsensor/archive/v2.2.0.zip'
 			onlyIfNewer true
 			quiet true


### PR DESCRIPTION
This is an attempt to fix a very weird error in gradle. It sometimes makes a zip out of a plain folder, without ever having been instructed to do so. As weren’t that enough, it’s also a Heisenbug, meaning we don’t know how to reproduce it.

This is an attempt to fix it, but as I don’t know how it’s caused this is a shot in the dark

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/773)
<!-- Reviewable:end -->
