### PR TITLE
Fix #770 - IllegalStateException

### DIFF
--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositorySeffExtractor.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositorySeffExtractor.java
@@ -43,6 +43,12 @@ public class PcmRepositorySeffExtractor {
 	private static final FailureHandler FAILURE_HANDLER = FailureHandler.getHandler("Beagle FileNotFound Handler");
 
 	/**
+	 * If Somox' generates no more output with multiple identifiers relating to the same
+	 * seffElements, this can be set to true.
+	 */
+	private static final boolean SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS = false;
+	
+	/**
 	 * Temporary storage for all extracted {@link SeffLoop SeffLoops} that should be
 	 * written on the {@link Blackboard}.
 	 */
@@ -93,11 +99,6 @@ public class PcmRepositorySeffExtractor {
 	 */
 	private final PcmCodeSectionGenerator codeSectionGenerator;
 
-	/**
-	 * If Somox' generates no more output with multiple identifiers relating to the same
-	 * seffElements, this can be set to true.
-	 */
-	private final boolean somoxIdentifiersAreUnambiguous = false;
 
 	/**
 	 * Constructor needs access to the real sets (no copy!), manipulating them by adding
@@ -381,7 +382,7 @@ public class PcmRepositorySeffExtractor {
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final ResourceDemandingInternalAction rdia,
 		final String identifier) {
-		if (this.somoxIdentifiersAreUnambiguous) {
+		if (SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS) {
 			return false;
 		}
 
@@ -402,7 +403,7 @@ public class PcmRepositorySeffExtractor {
 	 *         {@false}.
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final ExternalCallParameter exParam, final String identifier) {
-		if (this.somoxIdentifiersAreUnambiguous) {
+		if (SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS) {
 			return false;
 		}
 
@@ -424,7 +425,7 @@ public class PcmRepositorySeffExtractor {
 	 *         {@false}.
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final SeffBranch seffBranch, final String identifier) {
-		if (this.somoxIdentifiersAreUnambiguous) {
+		if (SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS) {
 			return false;
 		}
 
@@ -446,7 +447,7 @@ public class PcmRepositorySeffExtractor {
 	 *         {@false}.
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final SeffLoop seffLoop, final String identifier) {
-		if (this.somoxIdentifiersAreUnambiguous) {
+		if (SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS) {
 			return false;
 		}
 

--- a/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositorySeffExtractor.java
+++ b/Core/src/main/java/de/uka/ipd/sdq/beagle/core/pcmconnection/PcmRepositorySeffExtractor.java
@@ -376,9 +376,9 @@ public class PcmRepositorySeffExtractor {
 	 *
 	 * @param rdia the seffElement to check
 	 * @param identifier the Identifier to check
-	 * @return {@true} if there are no collisions otherwise {@false}. May be shut down by
-	 *         the variable {@link #somoxIdentifiersWorkCorrectly} and returning always
-	 *         {@false}.
+	 * @return {@code true} if there are no collisions otherwise {@code false}. May be shut down by
+	 *         the variable {@link #SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS} and returning always
+	 *         {@code false}.
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final ResourceDemandingInternalAction rdia,
 		final String identifier) {
@@ -398,9 +398,9 @@ public class PcmRepositorySeffExtractor {
 	 *
 	 * @param exParam the seffElement to check
 	 * @param identifier the Identifier to check
-	 * @return {@true} if there are no collisions otherwise {@false}. May be shut down by
-	 *         the variable {@link #somoxIdentifiersWorkCorrectly} and returning always
-	 *         {@false}.
+	 * @return {@code true} if there are no collisions otherwise {@code false}. May be shut down by
+	 *         the variable {@link #SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS} and returning always
+	 *         {@code false}.
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final ExternalCallParameter exParam, final String identifier) {
 		if (SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS) {
@@ -420,9 +420,9 @@ public class PcmRepositorySeffExtractor {
 	 *
 	 * @param seffBranch the seffElement to check
 	 * @param identifier the Identifier to check
-	 * @return {@true} if there are no collisions otherwise {@false}. May be shut down by
-	 *         the variable {@link #somoxIdentifiersWorkCorrectly} and returning always
-	 *         {@false}.
+	 * @return {@code true} if there are no collisions otherwise {@code false}. May be shut down by
+	 *         the variable {@link #SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS} and returning always
+	 *         {@code false}.
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final SeffBranch seffBranch, final String identifier) {
 		if (SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS) {
@@ -442,9 +442,9 @@ public class PcmRepositorySeffExtractor {
 	 *
 	 * @param seffLoop the seffElement to check
 	 * @param identifier the Identifier to check
-	 * @return {@true} if there are no collisions otherwise {@false}. May be shut down by
-	 *         the variable {@link #somoxIdentifiersWorkCorrectly} and returning always
-	 *         {@false}.
+	 * @return {@code true} if there are no collisions otherwise {@code false}. May be shut down by
+	 *         the variable {@link #SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS} and returning always
+	 *         {@code false}.
 	 */
 	private boolean shouldBeIgnoredDueToSomoxCollision(final SeffLoop seffLoop, final String identifier) {
 		if (SOMOX_IDENTIFIERS_ARE_UNAMBIGUOUS) {


### PR DESCRIPTION
Fixes #770 
Solution:
- Introduced a variable to define if Somox' identifiers are unambigous.

- Added methods to check if the same SeffElements exists for different identifiers

- Prevented the addition of SeffElements with ambigous identifiers (More detailed: if a SeffElement should be added, but it is already known with another identifer, the addition will be prevented)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/800)
<!-- Reviewable:end -->
