### PR TITLE
Instrumentation Improvements

### DIFF
--- a/Kieker Measurement Tool/src/main/java/de/uka/ipd/sdq/beagle/measurement/kieker/instrumentation/AstStatementInserter.java
+++ b/Kieker Measurement Tool/src/main/java/de/uka/ipd/sdq/beagle/measurement/kieker/instrumentation/AstStatementInserter.java
@@ -3,6 +3,7 @@ package de.uka.ipd.sdq.beagle.measurement.kieker.instrumentation;
 import org.apache.commons.lang3.Validate;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 
@@ -186,7 +187,7 @@ class AstStatementInserter {
 	 *
 	 * @author Joshua Gleitze
 	 */
-	private static final class ListInsertionStrategy implements InsertionStrategy {
+	private final class ListInsertionStrategy implements InsertionStrategy {
 
 		/**
 		 * The list to insert in.
@@ -212,8 +213,13 @@ class AstStatementInserter {
 
 		@Override
 		public void insert(final Statement statementToInsert, final int insertionOffset) {
-			this.list.add(this.index + insertionOffset, statementToInsert);
-			if (insertionOffset <= 0) {
+			int saveInsertionOffset = insertionOffset;
+			// hot fix for return statements.
+			if (this.list.get(this.index) instanceof ReturnStatement) {
+				saveInsertionOffset = Math.min(saveInsertionOffset, 0);
+			}
+			this.list.add(this.index + saveInsertionOffset, statementToInsert);
+			if (saveInsertionOffset <= 0) {
 				this.index++;
 			}
 		}

--- a/Kieker Measurement Tool/src/main/java/de/uka/ipd/sdq/beagle/measurement/kieker/instrumentation/EclipseAstInstrumentationStrategy.java
+++ b/Kieker Measurement Tool/src/main/java/de/uka/ipd/sdq/beagle/measurement/kieker/instrumentation/EclipseAstInstrumentationStrategy.java
@@ -14,7 +14,9 @@ import org.eclipse.jdt.core.dom.Statement;
 public interface EclipseAstInstrumentationStrategy {
 
 	/**
-	 * Provides a node to be inserted before {@code codeSection}.
+	 * Provides a node to be inserted before the given {@code codeSection}. The statement
+	 * returned is to be inserted before the first statement of the given
+	 * {@code codeSection}.
 	 *
 	 * @param codeSection The section being instrumented.
 	 * @param nodeFactory The {@linkplain AST} instance that must be used to create the
@@ -26,7 +28,9 @@ public interface EclipseAstInstrumentationStrategy {
 	Statement instrumentStart(CodeSection codeSection, AST nodeFactory);
 
 	/**
-	 * Provides a node to be inserted after {@code codeSection}.
+	 * Provides a node to be inserted after the given {@code codeSection}. The statement
+	 * returned is to be inserted after the last statement of the given
+	 * {@code codeSection}.
 	 *
 	 * @param codeSection The section being instrumented.
 	 * @param nodeFactory The {@linkplain AST} instance that must be used to create the

--- a/Kieker Measurement Tool/src/main/java/de/uka/ipd/sdq/beagle/measurement/kieker/instrumentation/InstrumentationInformation.java
+++ b/Kieker Measurement Tool/src/main/java/de/uka/ipd/sdq/beagle/measurement/kieker/instrumentation/InstrumentationInformation.java
@@ -82,7 +82,7 @@ class InstrumentationInformation {
 	 *            after an AST node.
 	 */
 	void addAfterStatementFunction(final Function<AST, Statement> afterStatementProvider) {
-		this.beforeStatement.add(afterStatementProvider);
+		this.afterStatement.add(afterStatementProvider);
 	}
 
 	/**


### PR DESCRIPTION
This PR contains some small code improvements and two bug fixes.

For the time being, if we’re trying to instrument directly after a `return`, we simply instrument before it. This fix does not cover all cases (e.g. `return` hidden in blocks). However, a true solution to the problem requires a lot of time which I unfortunately do not have (although writing the solution would surely be fun).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/beagle-pse/beagle/809)
<!-- Reviewable:end -->
